### PR TITLE
chore: pull and run pkger on main branch CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "lance/fix-ci-again"
 jobs:
   test:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,54 +4,26 @@ on:
   push:
     branches:
       - "main"
-
+      - "lance/fix-ci-again"
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: 'ubuntu-latest'
     steps:
-      # Checkout and test
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-      - name: Determine platform binaries
-        id: pkger-binaries
-        uses: actions/github-script@v2
-        with:
-          result-encoding: string
-          script: |
-            let platform, binary;
-            switch ('${{matrix.os}}') {
-              case 'ubuntu-latest':
-                platform = 'Linux_x86'
-                binary = 'pkger'
-                break
-              case 'windows-latest':
-                platform = 'Windows_x86'
-                binary = 'pkger.exe'
-                break
-              case 'macos-latest':
-                platform = 'Darwin_x86'
-                binary = 'pkger'
-                break
-            }
-            core.setOutput('platform', platform)
-            core.setOutput('binary', binary)
-      - name: Determine download URL for latest pkger
+      - name: Determine download URL for pkger
         id: pkger-download-url
         uses: actions/github-script@v2
         with:
           result-encoding: string
           script: |
-            let platform = "${{ steps.pkger-binaries.outputs.platform }}"
-            let binary = "${{ steps.pkger-binaries.outputs.binary }}"
-            core.info('PLATFORM: ' + platform)
-            core.info('BINARY: ' + binary)
             return github.repos.getReleaseByTag({
                 owner: "markbates",
                 repo: "pkger",
                 tag: "v0.17.1"
             }).then(result => {
                 return result.data.assets
-                  .filter(a => a.name.includes(platform))
+                  .filter(a => a.name.includes('Linux_x86'))
                   .map(a => a.browser_download_url)[0];
             })
       - name: Install pkger
@@ -62,7 +34,18 @@ jobs:
         run:  make test
         env:
           PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
-      
+      - name: Lint
+        run: make check
+    outputs:
+      pkger: ${{ steps.pkger-download-url.outputs.result }}
+
+  build-and-publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout and test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
       # Create a release, or update the release PR
       - uses: GoogleCloudPlatform/release-please-action@v2.5.5
         id: release
@@ -71,16 +54,16 @@ jobs:
           release-type: simple
           bump-minor-pre-major: true
 
+      - name: Install pkger
+        run: |
+          curl -s -L -o pkger.tgz ${{ needs.test.outputs.pkger }}
+          tar xvzf pkger.tgz
+  
       # Standard build tasks
       - name: Build
         run:  make cross-platform
         env:
-          PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
-
-      - name: Lint
-        run: make check
-      - name: Permissions
-        run: chmod a+x func_*amd*
+          PKGER: "./pkger"
 
       # Upload all build artifacts whether it's a release or not
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
I started this by trying to run a build matrix, but it got complicated pretty
quickly, since this build actually does `make cross-platform`. If we want to
also run a platform matrix when things land on `main`, I think it would be best
if we modified `pull_requests.yaml` to also run on `main` as well as on pull
requests (and be renamed).

Signed-off-by: Lance Ball <lball@redhat.com>