### PR TITLE
chore: use 'npm ci' instead of 'npm install' for Node.js tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ test-binary:
 	go test -race -cover -coverprofile=coverage.out ./...
 
 test-node:
-	cd templates/node/events && npm install && npm test && rm -rf node_modules
-	cd templates/node/http && npm install && npm test && rm -rf node_modules
+	cd templates/node/events && npm ci && npm test && rm -rf node_modules
+	cd templates/node/http && npm ci && npm test && rm -rf node_modules
 
 test-quarkus:
 	cd templates/quarkus/events && mvn test


### PR DESCRIPTION
This will ensure that package-lock.json is not updated with patch releases
unintentionally - that should be done with intent.

Signed-off-by: Lance Ball <lball@redhat.com>