### PR TITLE
integration tests

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -69,3 +69,25 @@ jobs:
           PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
       - name: Lint
         run: make check
+
+  integration-test:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
+      - name: Provision Cluster
+        uses: lkingland/kind-action@v1 # use ./hack/allocate.sh locally
+        with:
+          version: v0.10.0
+          kubectl_version: v1.20.0
+          knative_serving: v0.20.0
+          knative_kourier: v0.20.0
+          knative_eventing: v0.20.0
+          config: testdata/cluster.yaml
+      - name: Configure Cluster
+        run: ./hack/configure.sh
+      - name: Integration Test
+        run: make test-integration
+

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ build: all
 all: $(TEMPLATE_PACKAGE) $(BIN)
 
 $(TEMPLATE_PACKAGE): templates $(TEMPLATE_DIRS) $(TEMPLATE_FILES)
+	# to install pkger:  go get github.com/markbates/pkger/cmd/pkger
 	$(PKGER)
 
 cross-platform: $(TEMPLATE_PACKAGE) $(DARWIN) $(LINUX) $(WINDOWS)

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,11 @@ release: build test
 	git commit -am "release: $(VTAG)"
 	git tag $(VTAG)
 
+cluster: ## Set up a local cluster for integraiton tests.
+	# Creating KinD cluster `kind`.
+	# Delete with ./hack/delete.sh
+	./hack/allocate.sh && ./hack/configure.sh
+
 clean:
 	rm -f $(BIN) $(WINDOWS) $(LINUX) $(DARWIN)
 	-rm -f coverage.out

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ test-go:
 	cd templates/go/events && go test
 	cd templates/go/http && go test
 
+test-integration:
+	go test -tags integration ./...
+
 image: Dockerfile
 	docker build -t $(REPO):latest  \
 	             -t $(REPO):$(VERS) \

--- a/client.go
+++ b/client.go
@@ -368,6 +368,8 @@ func (c *Client) Create(cfg Function) (err error) {
 // not contain a populated Image.
 func (c *Client) Build(path string) (err error) {
 
+	fmt.Println("Building function image")
+
 	f, err := NewFunction(path)
 	if err != nil {
 		return
@@ -409,6 +411,7 @@ func (c *Client) Deploy(path string) (err error) {
 	}
 
 	// Push the image for the named service to the configured registry
+	fmt.Println("Pushing function image to the registry")
 	imageDigest, err := c.pusher.Push(f)
 	if err != nil {
 		return

--- a/client.go
+++ b/client.go
@@ -368,8 +368,6 @@ func (c *Client) Create(cfg Function) (err error) {
 // not contain a populated Image.
 func (c *Client) Build(path string) (err error) {
 
-	fmt.Println("Building function image")
-
 	f, err := NewFunction(path)
 	if err != nil {
 		return
@@ -411,7 +409,6 @@ func (c *Client) Deploy(path string) (err error) {
 	}
 
 	// Push the image for the named service to the configured registry
-	fmt.Println("Pushing function image to the registry")
 	imageDigest, err := c.pusher.Push(f)
 	if err != nil {
 		return

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -3,9 +3,15 @@
 package function_test
 
 import (
-	boson "github.com/boson-project/func"
-	"github.com/boson-project/func/knative"
+	"os"
+	"reflect"
 	"testing"
+	"time"
+
+	boson "github.com/boson-project/func"
+	"github.com/boson-project/func/buildpacks"
+	"github.com/boson-project/func/docker"
+	"github.com/boson-project/func/knative"
 )
 
 /*
@@ -35,7 +41,16 @@ import (
    ./hack/delete.sh
 */
 
-const DefaultNamespace = "func"
+const (
+	// DefaultRegistry must contain both the registry host and
+	// registry namespace at this time.  This will likely be
+	// split and defaulted to the forthcoming in-cluster registry.
+	DefaultRegistry = "localhost:5000/func"
+
+	// DefaultNamespace for the underlying deployments.  Must be the same
+	// as is set up and configured (see hack/configure.sh)
+	DefaultNamespace = "func"
+)
 
 func TestList(t *testing.T) {
 	verbose := true
@@ -58,5 +73,213 @@ func TestList(t *testing.T) {
 	// Assert
 	if len(names) != 0 {
 		t.Fatalf("Expected no Functions, got %v", names)
+	}
+}
+
+// TestNew creates
+func TestNew(t *testing.T) {
+	defer within(t, "testdata/example.com/testnew")()
+	verbose := true
+
+	client := newClient(verbose)
+
+	// Act
+	if err := client.New(boson.Function{Name: "testnew", Root: ".", Runtime: "go"}); err != nil {
+		t.Fatal(err)
+	}
+	defer del(t, client, "testnew")
+
+	// Assert
+	names, err := client.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"testnew"}) {
+		t.Fatalf("Expected function list ['testnew'], got %v", names)
+	}
+}
+
+// TestDeploy updates
+func TestDeploy(t *testing.T) {
+	defer within(t, "testdata/example.com/deploy")()
+	verbose := true
+
+	client := newClient(verbose)
+
+	if err := client.New(boson.Function{Name: "deploy", Root: ".", Runtime: "go"}); err != nil {
+		t.Fatal(err)
+	}
+	defer del(t, client, "deploy")
+
+	if err := client.Deploy("."); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRemove deletes
+func TestRemove(t *testing.T) {
+	defer within(t, "testdata/example.com/remove")()
+	verbose := true
+
+	client := newClient(verbose)
+
+	if err := client.New(boson.Function{Name: "remove", Root: ".", Runtime: "go"}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, client, "remove")
+
+	if err := client.Remove(boson.Function{Name: "remove"}); err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := client.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("Expected empty Functions list, got %v", names)
+	}
+}
+
+// ***********
+//   Helpers
+// ***********
+
+// newClient creates an instance of the func client whose concrete impls
+// match those created by the kn func plugin CLI.
+func newClient(verbose bool) *boson.Client {
+	builder := buildpacks.NewBuilder()
+	builder.Verbose = verbose
+
+	pusher := docker.NewPusher()
+	pusher.Verbose = verbose
+
+	deployer, err := knative.NewDeployer(DefaultNamespace)
+	if err != nil {
+		panic(err) // TODO: remove error from deployer constructor
+	}
+	deployer.Verbose = verbose
+
+	remover, err := knative.NewRemover(DefaultNamespace)
+	if err != nil {
+		panic(err) // TODO: remove error from remover constructor
+	}
+	remover.Verbose = verbose
+
+	lister, err := knative.NewLister(DefaultNamespace)
+	if err != nil {
+		panic(err) // TODO: remove error from lister constructor
+	}
+	lister.Verbose = verbose
+
+	return boson.New(
+		boson.WithRegistry(DefaultRegistry),
+		boson.WithVerbose(verbose),
+		boson.WithBuilder(builder),
+		boson.WithPusher(pusher),
+		boson.WithDeployer(deployer),
+		boson.WithRemover(remover),
+		boson.WithLister(lister),
+	)
+}
+
+// Del cleans up after a test by removing a function by name.
+// (test fails if the named function does not exist)
+//
+// Intended to be run in a defer statement immediately after creation, del
+// works around the asynchronicity of the underlying platform's creation
+// step by polling the provider until the names function becomes available
+// (or the test times out), before firing off a deletion request.
+// Of course, ideally this would be replaced by the use of a synchronous
+// method, or at a minimum a way to register a callback/listener for the
+// creation event.  This is what we have for now, and the show must go on.
+func del(t *testing.T, c *boson.Client, name string) {
+	t.Helper()
+	waitFor(t, c, name)
+	if err := c.Remove(boson.Function{Name: name}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// waitFor the named Function to become available in List output.
+// TODO: the API should be synchronous, but that depends first on
+// Create returning the derived name such that we can bake polling in.
+// Ideally the Boson provider's Creaet would be made syncrhonous.
+func waitFor(t *testing.T, c *boson.Client, name string) {
+	t.Helper()
+	var pollInterval = 2 * time.Second
+
+	for { // ever (i.e. defer to global test timeout)
+		nn, err := c.List()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, n := range nn {
+			if n.Name == name {
+				return
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+// Create the given directory, CD to it, and return a function which can be
+// run in a defer statement to return to the original directory and cleanup.
+// Note must be executed, not deferred itself
+// NO:  defer within(t, "somedir")
+// YES: defer within(t, "somedir")()
+func within(t *testing.T, root string) func() {
+	t.Helper()
+	cwd := pwd(t)
+	mkdir(t, root)
+	cd(t, root)
+	return func() {
+		cd(t, cwd)
+		rm(t, root)
+	}
+}
+
+func pwd(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func mkdir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func cd(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func rm(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func touch(file string) {
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		f, err := os.Create(file)
+		if err != nil {
+			panic(err)
+		}
+		defer f.Close()
+	}
+	t := time.Now().Local()
+	if err := os.Chtimes(file, t, t); err != nil {
+		panic(err)
 	}
 }

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -90,7 +90,11 @@ func TestNew(t *testing.T) {
 	defer del(t, client, "testnew")
 
 	// Assert
-	names, err := client.List()
+	items, err := client.List()
+	names := []string{}
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -1,0 +1,62 @@
+// +build integration
+
+package function_test
+
+import (
+	boson "github.com/boson-project/func"
+	"github.com/boson-project/func/knative"
+	"testing"
+)
+
+/*
+ NOTE:  Running integration tests locally requires a configured test cluster.
+        Test failures may require manual removal of dangling resources.
+
+ ## Integration Cluster
+
+ These integration tests require a properly configured cluster,
+ such as that which is setup and configured in CI (see .github/workflows).
+ A local KinD cluster can be started via:
+   ./hack/allocate.sh && ./hack/configure.sh
+
+ ## Integration Testing
+
+ These tests can be run via the make target:
+   make integration
+  or manually by specifying the tag
+   go test -v -tags integration ./...
+
+ ## Teardown and Cleanup
+
+ Tests should clean up after themselves.  In the event of failures, one may
+ need to manually remove files:
+   rm -rf ./testdata/example.com
+ The test cluster is not automatically removed, as it can be reused.  To remove:
+   ./hack/delete.sh
+*/
+
+const DefaultNamespace = "func"
+
+func TestList(t *testing.T) {
+	verbose := true
+
+	// Assemble
+	lister, err := knative.NewLister(DefaultNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := boson.New(
+		boson.WithLister(lister),
+		boson.WithVerbose(verbose))
+
+	// Act
+	names, err := client.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert
+	if len(names) != 0 {
+		t.Fatalf("Expected no Functions, got %v", names)
+	}
+}

--- a/client_int_test.go
+++ b/client_int_test.go
@@ -22,7 +22,7 @@ import (
  ## Integration Testing
 
  These tests can be run via the make target:
-   make integration
+   make test-integration
   or manually by specifying the tag
    go test -v -tags integration ./...
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package function_test
 
 import (

--- a/docker/runner_test.go
+++ b/docker/runner_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package docker_test
 
 import (

--- a/function_test.go
+++ b/function_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package function
 
 import "testing"
@@ -13,17 +15,17 @@ func TestFunction_ImageWithDigest(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "Full path with port",
+			name:   "Full path with port",
 			fields: fields{Image: "image-registry.openshift-image-registry.svc.cluster.local:5000/default/bar", ImageDigest: "42"},
 			want:   "image-registry.openshift-image-registry.svc.cluster.local:5000/default/bar@42",
 		},
 		{
-			name: "Path with namespace",
+			name:   "Path with namespace",
 			fields: fields{Image: "johndoe/bar", ImageDigest: "42"},
 			want:   "johndoe/bar@42",
 		},
 		{
-			name: "Just image name",
+			name:   "Just image name",
 			fields: fields{Image: "bar:latest", ImageDigest: "42"},
 			want:   "bar@42",
 		},

--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #
-# Allocate a local kind cluster with Knative and Kourier installed.
+# Allocate a Kind cluster with Knative, Kourier and a local container registry.
 #
 
 set -o errexit

--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Allocate a local kind cluster with Knative and Kourier installed.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+main() {
+
+  local serving_version=v0.20.0
+  local eventing_version=v0.20.0
+  local kourier_version=v0.20.0
+
+  local em=$(tput bold)$(tput setaf 2)
+  local me=$(tput sgr0)
+
+  echo "${em}Allocating...${me}"
+
+  cluster
+  serving
+  eventing
+  networking
+  registry
+  next_steps
+  
+  echo "${em}DONE${me}"
+}
+
+cluster() {
+  echo "${em}① Cluster${me}"
+  cat <<EOF | kind create cluster --wait=60s --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+    extraPortMappings:
+    - containerPort: 30080
+      hostPort: 80
+      listenAddress: "127.0.0.1"
+    - containerPort: 30443
+      hostPort: 443
+      listenAddress: "127.0.0.1"
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://kind-registry:5000"]
+EOF
+}
+
+serving() {
+  echo "${em}② Knative Serving${me}"
+  kubectl apply --filename https://github.com/knative/serving/releases/download/$serving_version/serving-crds.yaml
+  sleep 2
+  curl -L -s https://github.com/knative/serving/releases/download/$serving_version/serving-core.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+}
+
+eventing() {
+  echo "${em}③ Knative Eventing${me}"
+  kubectl apply --filename https://github.com/knative/eventing/releases/download/$eventing_version/eventing-crds.yaml
+  sleep 2
+  curl -L -s https://github.com/knative/eventing/releases/download/$eventing_version/eventing-core.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+  curl -L -s https://github.com/knative/eventing/releases/download/$eventing_version/in-memory-channel.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+  curl -L -s https://github.com/knative/eventing/releases/download/$eventing_version/mt-channel-broker.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+}
+
+networking() {
+  echo "${em}④ Kourier Networking${me}"
+  kubectl apply --filename https://github.com/knative-sandbox/net-kourier/releases/download/$kourier_version/kourier.yaml
+  kubectl patch configmap/config-network \
+      --namespace knative-serving \
+      --type merge \
+      --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+}
+
+
+registry() {
+  # see https://kind.sigs.k8s.io/docs/user/local-registry/
+
+  echo "${em}⑤ Container Registry${me}"
+  docker run -d --restart=always -p "5000:5000" --name "kind-registry" registry:2
+  docker network connect "kind" "kind-registry"
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:5000"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+}
+
+next_steps() {
+  local red=$(tput bold)$(tput setaf 1)
+
+  echo "${em}⑥ Configure Registry${me}"
+  echo "Please ${red}manually add 'kind-registry' to your local hosts${me} file:"
+  echo "  echo \"127.0.0.1 kind-registry\" | sudo tee --append /etc/hosts"
+
+  echo "Please ${red}manually set registry as insecure${me} in the docker daemon config (/etc/docker/daemon.json on linux or ~/.docker/daemon.json on OSX):
+  {
+    \"insecure-registries\": [ \"kind-registry:5000\" ],
+  }"
+
+}
+
+main "$@"

--- a/hack/configure.sh
+++ b/hack/configure.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 
+# Configures the current cluster for use with Functions
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DEFAULT_NAMESPACE=func
+
+show_help() {
+  cat << EOF
+  Configure a local cluster for use with Functions.
+
+  Usage: $(basename "$0") <options>
+
+    -h, --help                              Display help
+    -n, --namespace                         The namespace to use for Functions (default: $DEFAULT_NAMESPACE)
+EOF
+
+}
+
+main() {
+  local namespace="$DEFAULT_NAMESPACE"
+
+  local em=$(tput bold)$(tput setaf 2)
+  local me=$(tput sgr0)
+
+  parse_command_line "$@"
+
+  echo "${em}Configuring...${me}"
+
+  namespace 
+  network
+  kourier_nodeport
+  default_domain
+
+  sleep 10
+  kubectl --namespace kourier-system get service kourier
+
+  echo "${em}DONE${me}"
+}
+
+parse_command_line() {
+  while :; do
+    case "${1:-}" in
+      -h|--help)
+        show_help
+        exit
+        ;;
+      -n|--namespace)
+        if [[ -n "${2:-}" ]]; then
+          namespace="$2"
+          shift
+        else
+          echo "ERROR: '-n|--namespace' cannot be empty." >&2
+          show_help
+          exit 1
+        fi
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+}
+
+namespace() {
+  echo "${em}① Namespace${me}"
+  kubectl create namespace "$namespace"
+  kubectl label namespace "$namespace" knative-eventing-injection=enabled
+}
+
+network() {
+  echo "${em}② Network${me}"
+  echo "Registering Kourier as ingress"
+  echo "Enabling subdomains"
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+data:
+  # Use Kourier for the networking layer
+  ingress.class: kourier.ingress.networking.knative.dev
+
+  # If there exists an annotation 'func.subdomain' on the service, use it 
+  # instead of the default name.namespace
+  domainTemplate: |-
+    {{if index .Annotations "func.subdomain" -}}
+      {{- index .Annotations "func.subdomain" -}}
+    {{else -}}
+      {{- .Name}}.{{.Namespace -}}
+    {{end -}}
+    .{{.Domain}}
+
+EOF
+}
+
+kourier_nodeport() {
+  echo "${em}③ Nodeport${me}"
+  echo 'Setting Kourier service to type NodePort'
+  # Patch for changing kourier to a NodePort for installations where a 
+  # LoadBalancer is not available (for example local Kind clusters)
+  # kubectl patch -n kourier-system services/kourier -p "$(cat configure-kourier-nodeport.yaml)"
+  kubectl patch services/kourier \
+    --namespace kourier-system \
+    --type merge \
+    --patch '{
+  "spec": {
+    "ports": [
+      {
+        "name": "http2",
+        "nodePort": 30080,
+        "port": 80,
+        "protocol": "TCP",
+        "targetPort": 8080
+      },
+      {
+        "name": "https",
+        "nodePort": 30443,
+        "port": 443,
+        "protocol": "TCP",
+        "targetPort": 8443
+      }
+    ],
+    "type": "NodePort"
+  }
+}'
+}
+
+default_domain() {
+  echo "${em}④ Default Domains${me}"
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+data:
+  example.com: |
+    selector:
+      func.domain: "example.com"
+  example.org: |
+    selector:
+      func.domain: "example.org"
+  # Default is local only.
+  svc.cluster.local: ""
+EOF
+}
+
+main "$@"

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -1,0 +1,22 @@
+# Create a local kind cluster with
+# Knative Serving, and Kourier networking installed.
+# Suitable for use locally during development.
+# CI/CD uses the very similar knative-kind action
+
+main() {
+  local green=$(tput bold)$(tput setaf 2)
+  local red=$(tput bold)$(tput setaf 2)
+  local reset=$(tput sgr0)
+
+  echo "${green}Deleting Cluster, Registry and Network${reset}"
+  kind delete cluster --name "kind"
+  docker stop kind-registry && docker rm kind-registry
+  docker network rm kind
+  echo "${red}NOTE:${reset}  The following changes have not been undone:"
+  echo " - Manual etc/hosts entry for kind-registry"
+  echo " - Manual docker config registering kind-registry as insecure"
+  echo " - Downloaded container images were not removed"
+  echo "${green}DONE${reset}"
+}
+
+main

--- a/k8s/names_test.go
+++ b/k8s/names_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package k8s
 
 import "testing"
@@ -10,8 +12,8 @@ func TestToK8sAllowedName(t *testing.T) {
 		Out string
 		Err bool
 	}{
-		{"", "", true},        // invalid name
-		{"*", "", true},       // invalid name
+		{"", "", true},  // invalid name
+		{"*", "", true}, // invalid name
 		{"example", "example", true},
 		{"example.com", "example-com", false},
 		{"my-domain.com", "my--domain-com", false},

--- a/knative/remover.go
+++ b/knative/remover.go
@@ -7,6 +7,8 @@ import (
 	"github.com/boson-project/func/k8s"
 )
 
+const RemoveTimeout = 120 * time.Second
+
 func NewRemover(namespaceOverride string) (remover *Remover, err error) {
 	remover = &Remover{}
 	namespace, err := GetNamespace(namespaceOverride)
@@ -37,7 +39,7 @@ func (remover *Remover) Remove(name string) (err error) {
 
 	fmt.Printf("Removing Knative Service: %v\n", serviceName)
 
-	err = client.DeleteService(serviceName, time.Second*60)
+	err = client.DeleteService(serviceName, RemoveTimeout)
 	if err != nil {
 		err = fmt.Errorf("knative remover failed to delete the service: %v", err)
 	}

--- a/prompt/prompt_test.go
+++ b/prompt/prompt_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package prompt_test
 
 import (

--- a/templates.go
+++ b/templates.go
@@ -1,5 +1,10 @@
 package function
 
+// Updating Templates:
+// See documentation in ./templates/README.md
+// go get github.com/markbates/pkger
+//go:generate pkger
+
 import (
 	"errors"
 	"fmt"
@@ -11,9 +16,6 @@ import (
 
 	"github.com/markbates/pkger"
 )
-
-// Updating Templates:
-// See documentation in ./templates/README.md
 
 // DefautlTemplate is the default Function signature / environmental context
 // of the resultant template.  All runtimes are expected to have at least

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,18 +1,24 @@
 # Templates
 
-## Updating
+## Packaging
 
-When any templates are modified, `../pkged.go` should be regenerated.
+When updates are made to these templates, they must be packaged (serialized as
+a Go struture) by running `make`, and checking in the resultant `pkged.go` file.
 
-```
-go get github.com/markbates/pkger/cmd/pkger
-pkger
-```
-Generates a pkged.go containing serialized versions of the contents of 
-the templates directory, made accessible at runtime. 
+## How it works
+
+running `make` in turn installs the `pkger` binary, which can be installed via:
+`go get github.com/markbates/pkger/cmd/pkger`
+Make then invokes `pkger` before `go build`.
+
+The resulting `pkged.go` file includes the contents of the templates directory,
+encoded as a Go strucutres which is then makde available in code using an API
+similar to the standard library's `os` package.
+
+## Rationale
 
 Until such time as embedding static assets in binaries is included in the
-base go build functionality (see https://github.com/golang/go/issues/35950)
-a third-party tool is required and pkger provides an API largely compatible 
-with the os package.
+base `go build` functionality (see https://github.com/golang/go/issues/35950)
+a third-party tool is required and pkger provides an API very similar  
+to the `os` package.
 

--- a/templates_test.go
+++ b/templates_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package function
 
 import (

--- a/testdata/cluster.yaml
+++ b/testdata/cluster.yaml
@@ -1,0 +1,17 @@
+# Cluster config for the KinD cluster created for use in CI.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+    extraPortMappings:
+    - containerPort: 30080
+      hostPort: 80
+      listenAddress: "127.0.0.1"
+    - containerPort: 30443
+      hostPort: 443
+      listenAddress: "127.0.0.1"
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://kind-registry:5000"]


### PR DESCRIPTION
This PR adds the scaffolding necessary to run integration tests in GitHub using a local cluster and container registry.  Also includes scripts necessary to run them locally.

Fixes #138 