### PR TITLE
deploy --build option

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,6 +33,9 @@ type Client struct {
 	progressListener ProgressListener // progress listener
 }
 
+// ErrNotBuilt indicates the Function has not yet been built.
+var ErrNotBuilt = errors.New("not built")
+
 // Builder of Function source to runnable image.
 type Builder interface {
 	// Build a Function project with source located at path.
@@ -406,9 +409,10 @@ func (c *Client) Deploy(path string) (err error) {
 		return
 	}
 
-	// Build the Function
-	if err = c.Build(f.Root); err != nil {
-		return
+	// Functions must be built (have an associated image) before being deployed.
+	// Note that externally built images may be specified in the func.yaml
+	if !f.Built() {
+		return ErrNotBuilt
 	}
 
 	// Push the image for the named service to the configured registry

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ package function_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -52,25 +52,27 @@ kn func run [-p <path>]
 
 ## `deploy`
 
-Builds and deploys the Function project in the current directory. The user may specify a path to the project directory using the `--path` or `-p` flag. Reads the `func.yaml` configuration file to determine the image name. An image and registry may be specified on the command line using the  `--image` or `-i` and `--registry` or `-r` flag.
+Deploys the Function project in the current directory. The user may specify a path to the project directory using the `--path` or `-p` flag. Reads the `func.yaml` configuration file to determine the image name. An image and registry may be specified on the command line using the  `--image` or `-i` and `--registry` or `-r` flag.
 
 Derives the service name from the project name. There is no mechanism by which the user can specify the service name. The user must have already initialized the  function using `func create` or they will encounter an error.
 
 If the Function is already deployed, it is updated with a new container image that is pushed to a
 container image registry, and the Knative Service is updated.
 
+By default the Function image to be deployed is also built.  The build can be skipped by specifying `--build=false`.
+
 The namespace into which the project is deployed defaults to the value in the `func.yaml` configuration file. If `NAMESPACE` is not set in the configuration, the namespace currently active in the Kubernetes configuration file will be used. The namespace may be specified on the command line using the `--namespace` or `-n` flag, and if so this will overwrite the value in the `func.yaml` file.
 
 Similar `kn` command: `kn service create NAME --image IMAGE [flags]`. This command allows a user to deploy a Knative Service by specifying an image, typically one hosted on a public container registry such as docker.io. The deployment options which the `kn` command affords the user are quite broad. The `kn` command in this case is quite effective for a power user. The `func deploy` command has a similar end result, but is definitely easier for a user just getting started to be successful with.
 
 ```console
-func deploy [-n <namespace> -p <path> -i <image> -r <registry>]
+func deploy [-n <namespace> -p <path> -i <image> -r <registry> -b=true|false]
 ```
 
 When run as a `kn` plugin.
 
 ```console
-kn func deploy [-n <namespace> -p <path> -i <image> -r <registry>]
+kn func deploy [-n <namespace> -p <path> -i <image> -r <registry> -b=true|false]
 ```
 
 ## `describe`

--- a/function.go
+++ b/function.go
@@ -103,14 +103,24 @@ func (f Function) Initialized() bool {
 	return c.Runtime != "" && c.Name != ""
 }
 
+// Built indicates the Function has been built.  Does not guarantee the
+// image indicated actually exists, just that it _should_ exist based off
+// the current state of the Funciton object, in particular the value of
+// the Image and ImageDiget fields.
+func (f Function) Built() bool {
+	// If Image (the override) and ImageDigest (the most recent build stamp) are
+	// both empty, the Function is considered unbuilt.
+	return f.Image != "" || f.ImageDigest != ""
+}
+
 // ImageWithDigest returns the full reference to the image including SHA256 Digest.
 // If Digest is empty, image:tag is returned.
-func (f Function) ImageWithDigest() string{
+func (f Function) ImageWithDigest() string {
 	// Return image, if Digest is empty
 	if f.ImageDigest == "" {
 		return f.Image
 	}
-	
+
 	lastSlashIdx := strings.LastIndexAny(f.Image, "/")
 	imageAsBytes := []byte(f.Image)
 
@@ -118,7 +128,7 @@ func (f Function) ImageWithDigest() string{
 	part2 := string(imageAsBytes[lastSlashIdx+1:])
 
 	// Remove tag from the image name and append SHA256 hash instead
-	return part1 + strings.Split(part2, ":")[0] + "@" +f.ImageDigest
+	return part1 + strings.Split(part2, ":")[0] + "@" + f.ImageDigest
 }
 
 // DerivedImage returns the derived image name (OCI container tag) of the


### PR DESCRIPTION
Per Issue #272 , this PR adds the option to `deploy --build=false` such that a prebuilt image can be used and building bypassed.