### PR TITLE
ci: run release action prior to checkout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,6 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      # Checkout and test
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
       # Create a release, or update the release PR
       - uses: GoogleCloudPlatform/release-please-action@v2.5.5
         id: release
@@ -52,6 +49,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
           bump-minor-pre-major: true
+      # Checkout and test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
 
       - name: Install pkger
         run: |


### PR DESCRIPTION
In an attempt to fix the missing version on CI-built binaries, the repository is now checked out for the workflow after running the release action. This should ensure that the release action has fully completed, potentially adding any version tags to the codebase, prior to build's run which utilizes this version tag to populate the resultant binary's version number.