### PR TITLE
chore: fix versioning in CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Create a release, or update the release PR
-      - uses: GoogleCloudPlatform/release-please-action@v2.5.5
+      - uses: GoogleCloudPlatform/release-please-action@v2.24.1
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,6 +63,7 @@ jobs:
         run:  make cross-platform
         env:
           PKGER: "./pkger"
+          VERSION: ${{ steps.release.outputs.tag_name }}
 
       # Upload all build artifacts whether it's a release or not
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         run:  make cross-platform
         env:
           PKGER: "./pkger"
-          VERSION: ${{ steps.release.outputs.tag_name }}
+          VERS: ${{ steps.release.outputs.tag_name }}
 
       # Upload all build artifacts whether it's a release or not
       - uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ CODE := $(shell find . -name '*.go')
 DATE := $(shell date -u +"%Y%m%dT%H%M%SZ")
 HASH := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG := $(shell git tag --points-at HEAD)
-VERS := $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
+# a VERS environment variable takes precedence over git tags
+# due to issues with release-please-action tagging not working
+# as expected in CI
+VERS ?= $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
 
 TEMPLATE_DIRS=$(shell find templates -type d)
 TEMPLATE_FILES=$(shell find templates -type f -name '*')


### PR DESCRIPTION
For unknown reasons, the git tag for a release CI build via release-please
seems to happen after the build completes. It's a bit uncleear, but the
result is that we get v0.0.0 versions for released builds.

This commit modifies the Makefile to allow for an environment override of
the $VERS variable. Since the release-please-action documents `tag_name`
as output from the action, we can use this in CI to set the environment
variable.

Signed-off-by: Lance Ball <lball@redhat.com>