### PR TITLE
chore: adding references to guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Functions can be deployed on the following platforms:
 
 [Install the latest CLI](installing_cli.md)
 
-Functions can be created and managed using the CLI interactively, scripted, or by direct integration with the client library.   The [Function Developer's Guide](guides/developers_guide.md)and examples herein demonstrate the CLI-based approach.  
+Functions can be created and managed using the CLI interactively, scripted, or by direct integration with the client library. The [Function Developer's Guide](guides/developers_guide.md) and examples herein demonstrate the CLI-based approach.  
 
 For direct integration using the Go client library, it is advisible to first follow these CLI-based guides to become familiar with creating and deploying software in this way, and then proceed to the [Function Integrator's Guide](guides/integrators_guide.md).
 

--- a/docs/guides/developers_guide.md
+++ b/docs/guides/developers_guide.md
@@ -10,6 +10,14 @@ To learn how to work with functions quickly, have a look at the [developer's tut
 
 For detailed documentation on the CLI and its commands, please see the [Commands document](commands).
 
+## Function Project Configuration
+
+For detailed description of `func.yaml` file that is used for the Function project configuration, please see the [Project Configuration with `func.yaml` document](func_yaml.md).
+
+
 ## Language Guides
 
+* [Golang](golang.md)
 * [Node.js](nodejs.md)
+* [Python](python.md)
+* [Quarkus](quarkus.md)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Minor:
* adding links to the existing language guides to the Function developer guide
* adding link to the `func.yaml` guide which is coming in https://github.com/boson-project/func/pull/312