### PR TITLE
refactor!: change envVars to env in func.yaml

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -71,7 +71,7 @@ func runDeploy(cmd *cobra.Command, _ []string) (err error) {
 		return
 	}
 
-	function.EnvVars = mergeEnvVarsMaps(function.EnvVars, config.EnvVars)
+	function.Env = mergeEnvMaps(function.Env, config.Env)
 
 	// Check if the Function has been initialized
 	if !function.Initialized() {
@@ -250,7 +250,7 @@ type deployConfig struct {
 	// Build the associated Function before deploying.
 	Build bool
 
-	EnvVars map[string]string
+	Env map[string]string
 }
 
 // newDeployConfig creates a buildConfig populated from command flags and
@@ -263,7 +263,7 @@ func newDeployConfig(cmd *cobra.Command) deployConfig {
 		Verbose:     viper.GetBool("verbose"), // defined on root
 		Confirm:     viper.GetBool("confirm"),
 		Build:       viper.GetBool("build"),
-		EnvVars:     envVarsFromCmd(cmd),
+		Env:         envFromCmd(cmd),
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/ory/viper"
@@ -252,25 +253,25 @@ func deriveImage(explicitImage, defaultRegistry, path string) string {
 	return derivedValue // Use the func system's derivation logic.
 }
 
-func envVarsFromCmd(cmd *cobra.Command) map[string]string {
-	envVarsM := make(map[string]string)
+func envFromCmd(cmd *cobra.Command) map[string]string {
+	envM := make(map[string]string)
 	if cmd.Flags().Changed("env") {
-		envVarsA, err := cmd.Flags().GetStringArray("env")
+		envA, err := cmd.Flags().GetStringArray("env")
 		if err == nil {
-			for _, s := range envVarsA {
+			for _, s := range envA {
 				kvp := strings.Split(s, "=")
 				if len(kvp) == 2 && kvp[0] != "" {
-					envVarsM[kvp[0]] = kvp[1]
+					envM[kvp[0]] = kvp[1]
 				} else if len(kvp) == 1 && kvp[0] != "" {
-					envVarsM[kvp[0]] = ""
+					envM[kvp[0]] = ""
 				}
 			}
 		}
 	}
-	return envVarsM
+	return envM
 }
 
-func mergeEnvVarsMaps(dest, src map[string]string) map[string]string {
+func mergeEnvMaps(dest, src map[string]string) map[string]string {
 	result := make(map[string]string, len(dest)+len(src))
 
 	for name, value := range dest {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 
@@ -44,7 +45,7 @@ func runRun(cmd *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	function.EnvVars = mergeEnvVarsMaps(function.EnvVars, config.EnvVars)
+	function.Env = mergeEnvMaps(function.Env, config.Env)
 
 	err = function.WriteConfig()
 	if err != nil {
@@ -75,13 +76,13 @@ type runConfig struct {
 	// Verbose logging.
 	Verbose bool
 
-	EnvVars map[string]string
+	Env map[string]string
 }
 
 func newRunConfig(cmd *cobra.Command) runConfig {
 	return runConfig{
 		Path:    viper.GetString("path"),
 		Verbose: viper.GetBool("verbose"), // defined on root
-		EnvVars: envVarsFromCmd(cmd),
+		Env:     envFromCmd(cmd),
 	}
 }

--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ type config struct {
 	Trigger     string            `yaml:"trigger"`
 	Builder     string            `yaml:"builder"`
 	BuilderMap  map[string]string `yaml:"builderMap"`
-	EnvVars     map[string]string `yaml:"envVars"`
+	Env         map[string]string `yaml:"env"`
 	// Add new values to the toConfig/fromConfig functions.
 }
 
@@ -60,7 +60,7 @@ func fromConfig(c config) (f Function) {
 		Trigger:     c.Trigger,
 		Builder:     c.Builder,
 		BuilderMap:  c.BuilderMap,
-		EnvVars:     c.EnvVars,
+		Env:         c.Env,
 	}
 }
 
@@ -75,7 +75,7 @@ func toConfig(f Function) config {
 		Trigger:     f.Trigger,
 		Builder:     f.Builder,
 		BuilderMap:  f.BuilderMap,
-		EnvVars:     f.EnvVars,
+		Env:         f.Env,
 	}
 }
 

--- a/docker/runner.go
+++ b/docker/runner.go
@@ -3,14 +3,15 @@ package docker
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/docker/docker/client"
 
@@ -42,8 +43,8 @@ func (n *Runner) Run(ctx context.Context, f bosonFunc.Function) error {
 		return errors.New("Function has no associated Image. Has it been built?")
 	}
 
-	envs := make([]string, 0, len(f.EnvVars)+1)
-	for name, value := range f.EnvVars {
+	envs := make([]string, 0, len(f.Env)+1)
+	for name, value := range f.Env {
 		if !strings.HasSuffix(name, "-") {
 			envs = append(envs, fmt.Sprintf("%s=%s", name, value))
 		}

--- a/function.go
+++ b/function.go
@@ -52,7 +52,7 @@ type Function struct {
 	// e.g. { "jvm": "docker.io/example/quarkus-jvm-builder" }
 	BuilderMap map[string]string
 
-	EnvVars map[string]string
+	Env map[string]string
 }
 
 // NewFunction loads a Function from a path on disk. use .Initialized() to determine if


### PR DESCRIPTION
There are some places where I've changed variable and function names
where it wasn't strictly necessary. If you don't mind the bit of churn
that results, changing these makes `rg -i envvars` a nice way to check
for anything that could be overlooked.

Signed-off-by: Lance Ball <lball@redhat.com>