### PR TITLE
Draft releases through synchronous tagging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,10 +49,29 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
           bump-minor-pre-major: true
-      # Checkout and test
+      # Checkout
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      # Tag
+      # If a release was created, tag `vX.Y.Z` synchronously which:
+      #   1. Triggers release-please to create draft release, allowing manual
+      #      proofreading (and probably editing) of release notes.
+      #      (often raw commit messages are a bit overwhelming, overly granular
+      #      or at least could use some context when included as release notes).
+      #   2. Ensures the tag exists for subsequent action tasks which rely on
+      #      this metadata, such as including version in release binaries.
+      #      The release-please action does add this tag, but asynchronously.
+      # Note that tag is created annotated such that it shows tagging metadata
+      # when queried rather than just the associated commit metadata.
+      - name: tag
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          git config user.name github-actions[bot]
+          git tag -d v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} || true
+          git push origin :v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} || true
+          git tag -a v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} -m "Release v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}}"
+          git push origin v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} || true
 
+      - uses: actions/setup-go@v2
       - name: Install pkger
         run: |
           curl -s -L -o pkger.tgz ${{ needs.test.outputs.pkger }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,14 @@ jobs:
         run:  make cross-platform
         env:
           PKGER: "./pkger"
-          VERS: ${{ steps.release.outputs.tag_name }}
+          # NOTE:
+          # release-please adds the version asynchronously. Without using the
+          # synchonous tagging step above, the version can be explicitly passed
+          # to the build using the following environment variable.  However this
+          # has the side-effect of causing inter-relese binaries to not include
+          # verbose version information, because the special version `tip` is
+          # overriden with a blank string in those cases.
+          # VERS: ${{ steps.release.outputs.tag_name }}
 
       # Upload all build artifacts whether it's a release or not
       - uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ DATE := $(shell date -u +"%Y%m%dT%H%M%SZ")
 HASH := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG := $(shell git tag --points-at HEAD)
 # a VERS environment variable takes precedence over git tags
-# due to issues with release-please-action tagging not working
-# as expected in CI
+# and is necessary with release-please-action which tags asynchronously
+# unless explicitly, synchronously tagging as is done in ci.yaml
 VERS ?= $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
 
 TEMPLATE_DIRS=$(shell find templates -type d)


### PR DESCRIPTION
After digging into the missing version tag issue a bit more, the digression did confirm that the release-please action is creating the tag asynchronously (at the octocat library level it seems, so a bit deep), as we surmised.  So no surprise there.  However, the process did turn up a couple somewhat interesting opportunities for improvement (or at least discussion) wherein we can ignore this asynchronicity by creating the tag, and in so doing enable draft releases.

First, this fixes a small bug introduced from passing the VERS as an environment variable.  While this did fix our acute issue of missing version in the released binaries caused by release-please's asynchronous tagging, it had the side-effect of removing verbose build information from our "interstitial" binaries (built between releases, on all pushes to main).  The empty value of the VERS environment variable overrides the detected "tip", and therefore the interstitial binaries no longer contain the version with the full verbose tag `tip-[hash]-[date]` but instead fall back to the catch-all `v0.0.0-source` which is the special value used when building directly from source `go build ...` when truly zero verbose version information is available (see [version.go for full logic](https://github.com/lkingland/func/blob/main/cmd/version.go#L71)).  This PR updates the process to explicitly, synchronously tag the version, such that the metadata is included in the repository at build time.

Second, as a side-effect of synchronously tagging, we get the benefit of draft releases from the release bot. It seems to me this is very helpful, and not an option explicitly exposed by the action.  To have our release-please bot create releases as _drafts_, it allows us a chance to proofread/edit the release notes etc.  Git commit messages can sometimes be a bit too granular, confusing, overly technical, easily summarizable, or otherwise in need of some context/massaging prior to being included as official release notes.  Or, at a minimum a quick proofread is a good idea.  Also, I would surmise that we will often want to add some additional information about a release beyond what is included in the auto-generated log.  This PR triggers a draft release by synchronously tagging the version.  This puts a human in the loop allowing those edits to take place, or a single "publish" button push otherwise.

The effects included in this PR are coupled.  A fix to the missing verbose version information in interstitial builds through synchronously tagging the version always enables draft releases.  I personally prefer draft releases, but if that is not desirable to the rest of the team, we can always fall back to using the VERS environment variable along with asynchronous tagging, and perhaps tweak the makefile to detect empty values instead.

See the comment block added to the pertinent section of ci.yaml which is a bit more to the point:
```
      # Tag
      # If a release was created, tag `vX.Y.Z` synchronously which:
      #   1. Triggers release-please to create draft release, allowing manual
      #      proofreading (and probably editing) of release notes.
      #      (often raw commit messages are a bit overwhelming, overly granular
      #      or at least could use some context when included as release notes).
      #   2. Ensures the tag exists for subsequent action tasks which rely on
      #      this metadata, such as including version in release binaries.
      #      The release-please action does add this tag, but asynchronously.
      # Note that tag is created annotated such that it shows tagging metadata
      # when queried rather than just the associated commit metadata.
```