### PR TITLE
fix: func delete with explicity name as argument (#323)

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -42,17 +42,31 @@ kn func delete -n apps myfunc
 	RunE:              runDelete,
 }
 
+
 func runDelete(cmd *cobra.Command, args []string) (err error) {
 	config := newDeleteConfig(args).Prompt()
+	
+	var function fn.Function
 
-	function, err := fn.NewFunction(config.Path)
-	if err != nil {
-		return
-	}
+	// Initialize func with explicit name (when provided)
+	if len(args) > 0 && args[0] != "" {
+		pathChanged := cmd.Flags().Changed("path")
+		if pathChanged {
+			return fmt.Errorf("Only one of --path and [NAME] should be provided")
+		}
+		function = fn.Function{
+			Name: args[0],
+		}
+	} else {
+		function, err = fn.NewFunction(config.Path)
+		if err != nil {
+			return
+		}
 
-	// Check if the Function has been initialized
-	if !function.Initialized() {
-		return fmt.Errorf("the given path '%v' does not contain an initialized function", config.Path)
+		// Check if the Function has been initialized
+		if !function.Initialized() {
+			return fmt.Errorf("the given path '%v' does not contain an initialized function", config.Path)
+		}
 	}
 
 	ns := config.Namespace

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -66,7 +66,10 @@ annotations: {}
 	}
 	defer f.Close()
 
-	f.WriteString(funcYaml)
+	_, err = f.WriteString(funcYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
 	f.Close()
 
 
@@ -74,8 +77,13 @@ annotations: {}
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chdir(oldWD)
-	err = 	os.Chdir(tmpDir)
+	defer func() {
+		err = os.Chdir(oldWD)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	err = os.Chdir(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/guides/commands.md
+++ b/docs/guides/commands.md
@@ -111,7 +111,7 @@ kn func list [-n <namespace> -p <path>]
 
 ## `delete`
 
-Removes a deployed function from the cluster. The user may specify a function by name, path or if neither of those are provided, the current directory will be searched for a `func.yaml` configuration file to determine the function to be removed. The namespace defaults to the value in `func.yaml` or the namespace currently active in the user's Kubernetes configuration. The namespace may be specified on the command line, and if so this will overwrite the value in `func.yaml`.
+Removes a deployed function from the cluster. The user may specify a function by name, path. If both of those are provided the command will not be executed and user will receive an error message. If neither of those are provided, the current directory will be searched for a `func.yaml` configuration file to determine the function to be removed. The namespace defaults to the value in `func.yaml` or the namespace currently active in the user's Kubernetes configuration. The namespace may be specified on the command line, and if so this will overwrite the value in `func.yaml`.
 
 Similar `kn` command: `kn service delete NAME [flags]`.
 


### PR DESCRIPTION
Allows function to be delete when passing explicity name

```
$ func list | grep gofunc
gofunc            test-function  go          http://gofunc-test-function.apps-crc.testing            True
$ cd ~
$ ls -l func.yaml
ls: cannot access 'func.yaml': No such file or directory
$ func delete gofunc
Removing Knative Service: gofunc
$ func list | grep gofunc
$ 
```