### PR TITLE
chore: bump to Go 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/boson-project/func
 
-go 1.14
+go 1.15
 
 require (
 	github.com/buildpacks/pack v0.18.0


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Is there a particular reason why we are still at 1.14? Knative Client is using 1.15 - we should sync that.