### PR TITLE
feat: reference ConfigMaps in `envs` and `volumes` sections in config

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -12,6 +12,7 @@ func Test_validateVolumes(t *testing.T) {
 	path := "path"
 	secret2 := "secret2"
 	path2 := "path2"
+	cm := "configMap"
 
 	tests := []struct {
 		name    string
@@ -19,7 +20,7 @@ func Test_validateVolumes(t *testing.T) {
 		errs    int
 	}{
 		{
-			"correct entry - single volume",
+			"correct entry - single volume with secret",
 			Volumes{
 				Volume{
 					Secret: &secret,
@@ -29,7 +30,17 @@ func Test_validateVolumes(t *testing.T) {
 			0,
 		},
 		{
-			"correct entry - multiple volumes",
+			"correct entry - single volume with configmap",
+			Volumes{
+				Volume{
+					ConfigMap: &cm,
+					Path:      &path,
+				},
+			},
+			0,
+		},
+		{
+			"correct entry - multiple volumes with secrets",
 			Volumes{
 				Volume{
 					Secret: &secret,
@@ -43,7 +54,21 @@ func Test_validateVolumes(t *testing.T) {
 			0,
 		},
 		{
-			"missing secret - single volume",
+			"correct entry - multiple volumes with both secret and configMap",
+			Volumes{
+				Volume{
+					Secret: &secret,
+					Path:   &path,
+				},
+				Volume{
+					ConfigMap: &cm,
+					Path:      &path2,
+				},
+			},
+			0,
+		},
+		{
+			"missing secret/configMap - single volume",
 			Volumes{
 				Volume{
 					Path: &path,
@@ -52,7 +77,7 @@ func Test_validateVolumes(t *testing.T) {
 			1,
 		},
 		{
-			"missing secret - single volume",
+			"missing path - single volume with secret",
 			Volumes{
 				Volume{
 					Secret: &secret,
@@ -61,14 +86,23 @@ func Test_validateVolumes(t *testing.T) {
 			1,
 		},
 		{
-			"missing secret and path - single volume",
+			"missing path - single volume with configMap",
+			Volumes{
+				Volume{
+					ConfigMap: &cm,
+				},
+			},
+			1,
+		},
+		{
+			"missing secret/configMap and path - single volume",
 			Volumes{
 				Volume{},
 			},
 			1,
 		},
 		{
-			"missing secret in one volume - multiple volumes",
+			"missing secret/configMap in one volume - multiple volumes",
 			Volumes{
 				Volume{
 					Secret: &secret,
@@ -81,7 +115,7 @@ func Test_validateVolumes(t *testing.T) {
 			1,
 		},
 		{
-			"missing secret and path in two different volumes - multiple volumes",
+			"missing secret/configMap and path in two different volumes - multiple volumes",
 			Volumes{
 				Volume{
 					Secret: &secret,
@@ -128,6 +162,7 @@ func Test_validateEnvs(t *testing.T) {
 	valueSecretKeyIncorrect := "{{ secret.my-secret.key.key }}"
 	valueSecretKeyIncorrect2 := "{{ my-secret.key }}"
 	valueSecretKeyIncorrect3 := "{{ secret.my-secret.key }}foo"
+	valueConfigMapKey := "{{ configMap.myconfigmap.key }}"
 
 	valueSecret := "{{ secret.my-secret }}"
 	valueSecret2 := "{{ secret.mysecret }}"
@@ -135,6 +170,7 @@ func Test_validateEnvs(t *testing.T) {
 	valueSecretIncorrect := "{{ my-secret }}"
 	valueSecretIncorrect2 := "my-secret"
 	valueSecretIncorrect3 := "{{ secret.my-secret }}foo"
+	valueConfigMap := "{{ configMap.myconfigmap }}"
 
 	tests := []struct {
 		name string
@@ -247,6 +283,16 @@ func Test_validateEnvs(t *testing.T) {
 			0,
 		},
 		{
+			"correct entry - single configMap with key",
+			Envs{
+				Env{
+					Name:  &name,
+					Value: &valueConfigMapKey,
+				},
+			},
+			0,
+		},
+		{
 			"correct entry - multiple secrets with key",
 			Envs{
 				Env{
@@ -260,6 +306,20 @@ func Test_validateEnvs(t *testing.T) {
 				Env{
 					Name:  &name,
 					Value: &valueSecretKey3,
+				},
+			},
+			0,
+		},
+		{
+			"correct entry - both secret and configmap with key",
+			Envs{
+				Env{
+					Name:  &name,
+					Value: &valueSecretKey,
+				},
+				Env{
+					Name:  &name,
+					Value: &valueConfigMapKey,
 				},
 			},
 			0,
@@ -306,7 +366,16 @@ func Test_validateEnvs(t *testing.T) {
 			0,
 		},
 		{
-			"correct entry - multiple whole secret2",
+			"correct entry - single whole configMap",
+			Envs{
+				Env{
+					Value: &valueConfigMap,
+				},
+			},
+			0,
+		},
+		{
+			"correct entry - multiple whole secret",
 			Envs{
 				Env{
 					Value: &valueSecret,
@@ -321,6 +390,18 @@ func Test_validateEnvs(t *testing.T) {
 			0,
 		},
 		{
+			"correct entry - both whole secret and configMap",
+			Envs{
+				Env{
+					Value: &valueSecret,
+				},
+				Env{
+					Value: &valueConfigMap,
+				},
+			},
+			0,
+		},
+		{
 			"incorrect entry - single whole secret",
 			Envs{
 				Env{
@@ -330,7 +411,7 @@ func Test_validateEnvs(t *testing.T) {
 			1,
 		},
 		{
-			"incorrect entry - multiple whole secret2",
+			"incorrect entry - multiple whole secret",
 			Envs{
 				Env{
 					Value: &valueSecretIncorrect,
@@ -392,6 +473,9 @@ func Test_validateEnvs(t *testing.T) {
 					Value: &valueSecret3,
 				},
 				Env{
+					Value: &valueConfigMap,
+				},
+				Env{
 					Name:  &name,
 					Value: &valueSecretKey,
 				},
@@ -402,6 +486,10 @@ func Test_validateEnvs(t *testing.T) {
 				Env{
 					Name:  &name,
 					Value: &valueSecretKey3,
+				},
+				Env{
+					Name:  &name,
+					Value: &valueConfigMapKey,
 				},
 			},
 			0,

--- a/docs/guides/func_yaml.md
+++ b/docs/guides/func_yaml.md
@@ -34,27 +34,32 @@ The `envs` field allows you to set environment variables that will be
 available to your function at runtime. 
 1. Environment variable can be set directly from a value
 2. Environment variable can be set from a local environment value. Eg. `'{{ env.LOCAL_ENV_VALUE }}'`, for more details see [Local Environment Variables section](#local-environment-variables).
-3. Environment variable can be set from a key in a Kubernetes Secret. This Secret needs to be created before it is referenced in a function. Eg. `'{{ secret.mysecret.key }}'` where `mysecret` is the name of the Secret and `key` is the referenced key.
-4. All key-value pairs from a Kubernetes Secret will be set as environment variables. This Secret needs to be created before it is referenced in a function. Eg. `'{{ secret.mysecret2 }}'` where `mysecret2` is the name of the Secret.
+3. Environment variable can be set from a key in a Kubernetes Secret or ConfigMap. This Secret/ConfigMap needs to be created before it is referenced in a function. Eg. `'{{ secret.mysecret.key }}'` where `mysecret` is the name of the Secret and `key` is the referenced key; or `{{ configMap.myconfigmap.key }}` where `myconfigmap` is the name of the ConfigMap and `key` is the referenced key.
+4. All key-value pairs from a Kubernetes Secret or ConfigMap will be set as environment variables. This Secret/ConfigMap needs to be created before it is referenced in a function. Eg. `'{{ secret.mysecret2 }}'` where `mysecret2` is the name of the Secret; or `{{ configMap.myconfigmap }}` where `myconfigmap` is the name of the ConfigMap.
 
 ```yaml
 envs:
-- name: EXAMPLE1                       # (1) env variable directly from a value
+- name: EXAMPLE1                            # (1) env variable directly from a value
   value: value
-- name: EXAMPLE2                       # (2) env variable from a local environment value
+- name: EXAMPLE2                            # (2) env variable from a local environment value
   value: '{{ env.LOCAL_ENV_VALUE }}'
-- name: EXAMPLE3                       # (3) env variable from a key in Secret
+- name: EXAMPLE3                            # (3) env variable from a key in Secret
   value: '{{ secret.mysecret.key }}'
-- value: '{{ secret.mysecret2 }}'      # (4) all key-value pairs in Secret as env variables
+- name: EXAMPLE4                            # (3) env variable from a key in ConfigMap
+  value: '{{ configMap.myconfigmap.key }}'
+- value: '{{ secret.mysecret2 }}'           # (4) all key-value pairs in Secret as env variables
+- value: '{{ configMap.myconfigmap2 }}'     # (4) all key-value pairs in ConfigMap as env variables
 ```
 
 ### `volumes`
-Kubernetes Secrets can be mounted to the function as a Kubernetes Volume accessible under specified path. Below you can see an example how to mount the Secret `mysecret` to the path `/workspace/secret`. This Secret needs to be created before it is referenced in a function.
+Kubernetes Secrets or ConfigMaps can be mounted to the function as a Kubernetes Volume accessible under specified path. Below you can see an example how to mount the Secret `mysecret` to the path `/workspace/secret` and the ConfigMap `myconfigmap` to the path `/workspace/configmap`. This Secret/ConfigMap needs to be created before it is referenced in a function.
 
 ```yaml
 volumes:
 - secret: mysecret
   path: /workspace/secret
+- configMap: myconfigmap
+  path: /workspace/configmap
 ```
 
 ### `image`


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Follow up on #369, users can reference Kubernetes ConfigMaps in the `func.yaml`, in `envs` and `volumes` sections the same way it is done for Secrets, see the example:

```yaml
name: test
namespace: ""
runtime: go
...
volumes:
- configMap: mycm3
  path: /workspace/configmap
envs:
- name: EXAMPLE1
  value: myvalue
- name: EXAMPLE2
  value: '{{ env.LOCAL_ENV_VALUE }}'
- name: EXAMPLE3
  value: '{{ configMap.mycm2.EXAMPLE3 }}'
- value: '{{ configMap.mycm }}'
```

Relates: #362