### PR TITLE
chore: e2e tests should run against Knative 0.22.0

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -129,9 +129,9 @@ jobs:
         with:
           version: v0.10.0
           kubectl_version: v1.20.0
-          knative_serving: v0.20.0
-          knative_kourier: v0.20.0
-          knative_eventing: v0.20.0
+          knative_serving: v0.22.0
+          knative_kourier: v0.22.0
+          knative_eventing: v0.22.0
           config: testdata/cluster.yaml
       - name: Configure Cluster
         run: ./hack/configure.sh

--- a/hack/allocate.sh
+++ b/hack/allocate.sh
@@ -22,9 +22,9 @@ set -o pipefail
 
 main() {
 
-  local serving_version=v0.20.0
-  local eventing_version=v0.20.0
-  local kourier_version=v0.20.0
+  local serving_version=v0.22.0
+  local eventing_version=v0.22.0
+  local kourier_version=v0.22.0
 
   local em=$(tput bold)$(tput setaf 2)
   local me=$(tput sgr0)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

The rest of the codebase is using Knative 0.22.0.