### PR TITLE
feat: allow setting autoscaling options to deployed KService

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,15 +34,15 @@ type Options struct {
 }
 
 type ScaleOptions struct {
-	Min    *int64  `yaml:"min,omitempty"`
-	Max    *int64  `yaml:"max,omitempty"`
-	Metric *string `yaml:"metric,omitempty"`
+	Min         *int64   `yaml:"min,omitempty"`
+	Max         *int64   `yaml:"max,omitempty"`
+	Metric      *string  `yaml:"metric,omitempty"`
+	Target      *float64 `yaml:"target,omitempty"`
+	Utilization *float64 `yaml:"utilization,omitempty"`
 }
 
 type ConcurrencyOptions struct {
-	Limit       *int64   `yaml:"limit,omitempty"`
-	Target      *float64 `yaml:"target,omitempty"`
-	Utilization *float64 `yaml:"utilization,omitempty"`
+	Limit *int64 `yaml:"limit,omitempty"`
 }
 
 // Config represents the serialized state of a Function's metadata.
@@ -308,6 +308,21 @@ func validateOptions(options Options) (errors []string) {
 					*options.Scale.Metric))
 			}
 		}
+
+		if options.Scale.Target != nil {
+			if *options.Scale.Target < 0.01 {
+				errors = append(errors, fmt.Sprintf("options field \"scale.target\" has value set to \"%f\", but it must not be less than 0.01",
+					*options.Scale.Target))
+			}
+		}
+
+		if options.Scale.Utilization != nil {
+			if *options.Scale.Utilization < 1 || *options.Scale.Utilization > 100 {
+				errors = append(errors,
+					fmt.Sprintf("options field \"scale.utilization\" has value set to \"%f\", but it must not be less than 1 or greater than 100",
+						*options.Scale.Utilization))
+			}
+		}
 	}
 
 	// options.concurrency
@@ -316,21 +331,6 @@ func validateOptions(options Options) (errors []string) {
 			if *options.Concurrency.Limit < 0 {
 				errors = append(errors, fmt.Sprintf("options field \"concurrency.limit\" has value set to \"%d\", but it must not be less than 0",
 					*options.Concurrency.Limit))
-			}
-		}
-
-		if options.Concurrency.Target != nil {
-			if *options.Concurrency.Target < 0.01 {
-				errors = append(errors, fmt.Sprintf("options field \"concurrency.target\" has value set to \"%f\", but it must not be less than 0.01",
-					*options.Concurrency.Target))
-			}
-		}
-
-		if options.Concurrency.Utilization != nil {
-			if *options.Concurrency.Utilization < 1 || *options.Concurrency.Utilization > 100 {
-				errors = append(errors,
-					fmt.Sprintf("options field \"concurrency.utilization\" has value set to \"%f\", but it must not be less than 1 or greater than 100",
-						*options.Concurrency.Utilization))
 			}
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -29,8 +29,7 @@ type Env struct {
 }
 
 type Options struct {
-	Scale       *ScaleOptions       `yaml:"scale,omitempty"`
-	Concurrency *ConcurrencyOptions `yaml:"concurrency,omitempty"`
+	Scale *ScaleOptions `yaml:"scale,omitempty"`
 }
 
 type ScaleOptions struct {
@@ -39,10 +38,6 @@ type ScaleOptions struct {
 	Metric      *string  `yaml:"metric,omitempty"`
 	Target      *float64 `yaml:"target,omitempty"`
 	Utilization *float64 `yaml:"utilization,omitempty"`
-}
-
-type ConcurrencyOptions struct {
-	Limit *int64 `yaml:"limit,omitempty"`
 }
 
 // Config represents the serialized state of a Function's metadata.
@@ -321,16 +316,6 @@ func validateOptions(options Options) (errors []string) {
 				errors = append(errors,
 					fmt.Sprintf("options field \"scale.utilization\" has value set to \"%f\", but it must not be less than 1 or greater than 100",
 						*options.Scale.Utilization))
-			}
-		}
-	}
-
-	// options.concurrency
-	if options.Concurrency != nil {
-		if options.Concurrency.Limit != nil {
-			if *options.Concurrency.Limit < 0 {
-				errors = append(errors, fmt.Sprintf("options field \"concurrency.limit\" has value set to \"%d\", but it must not be less than 0",
-					*options.Concurrency.Limit))
 			}
 		}
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,8 @@ package function
 
 import (
 	"testing"
+
+	"knative.dev/pkg/ptr"
 )
 
 func Test_validateVolumes(t *testing.T) {
@@ -500,6 +502,91 @@ func Test_validateEnvs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ValidateEnvs(tt.envs); len(got) != tt.errs {
 				t.Errorf("validateEnvs() = %v\n got %d errors but want %d", got, len(got), tt.errs)
+			}
+		})
+	}
+
+}
+
+func Test_validateOptions(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		options Options
+		errs    int
+	}{
+		{
+			"correct 'autoscale-window'",
+			Options{
+				AutoscaleWindow: ptr.String("10s"),
+			},
+			0,
+		},
+		{
+			"incorrect 'autoscale-window' - missing unit",
+			Options{
+				AutoscaleWindow: ptr.String("10"),
+			},
+			1,
+		},
+		{
+			"incorrect 'autoscale-window' - wrong string",
+			Options{
+				AutoscaleWindow: ptr.String("foo"),
+			},
+			1,
+		},
+		{
+			"correct 'concurrency-limit'",
+			Options{
+				ConcurrencyLimit: ptr.Int64(50),
+			},
+			0,
+		},
+		{
+			"correct 'concurrency-limit' - 0",
+			Options{
+				ConcurrencyLimit: ptr.Int64(0),
+			},
+			0,
+		},
+		{
+			"incorrect 'concurrency-limit' - negative value",
+			Options{
+				ConcurrencyLimit: ptr.Int64(-10),
+			},
+			1,
+		},
+		{
+			"correct all options",
+			Options{
+				ConcurrencyLimit: ptr.Int64(50),
+				AutoscaleWindow:  ptr.String("10s"),
+			},
+			0,
+		},
+		{
+			"incorrect all options",
+			Options{
+				ConcurrencyLimit: ptr.Int64(-10),
+				AutoscaleWindow:  ptr.String("foo"),
+			},
+			2,
+		},
+		{
+			"incorrect and correct options",
+			Options{
+				ConcurrencyLimit: ptr.Int64(50),
+				AutoscaleWindow:  ptr.String("foo"),
+			},
+			1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateOptions(tt.options); len(got) != tt.errs {
+				t.Errorf("validateOptions() = %v\n got %d errors but want %d", got, len(got), tt.errs)
 			}
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -626,45 +626,45 @@ func Test_validateOptions(t *testing.T) {
 			1,
 		},
 		{
-			"correct 'concurrency.target'",
+			"correct 'scale.target'",
 			Options{
-				Concurrency: &ConcurrencyOptions{
+				Scale: &ScaleOptions{
 					Target: ptr.Float64(50),
 				},
 			},
 			0,
 		},
 		{
-			"incorrect 'concurrency.target'",
+			"incorrect 'scale.target'",
 			Options{
-				Concurrency: &ConcurrencyOptions{
+				Scale: &ScaleOptions{
 					Target: ptr.Float64(0),
 				},
 			},
 			1,
 		},
 		{
-			"correct 'concurrency.utilization'",
+			"correct 'scale.utilization'",
 			Options{
-				Concurrency: &ConcurrencyOptions{
+				Scale: &ScaleOptions{
 					Utilization: ptr.Float64(50),
 				},
 			},
 			0,
 		},
 		{
-			"incorrect 'concurrency.utilization' - < 1",
+			"incorrect 'scale.utilization' - < 1",
 			Options{
-				Concurrency: &ConcurrencyOptions{
+				Scale: &ScaleOptions{
 					Utilization: ptr.Float64(0),
 				},
 			},
 			1,
 		},
 		{
-			"incorrect 'concurrency.utilization' - > 100",
+			"incorrect 'scale.utilization' - > 100",
 			Options{
-				Concurrency: &ConcurrencyOptions{
+				Scale: &ScaleOptions{
 					Utilization: ptr.Float64(110),
 				},
 			},
@@ -674,14 +674,14 @@ func Test_validateOptions(t *testing.T) {
 			"correct all options",
 			Options{
 				Concurrency: &ConcurrencyOptions{
-					Limit:       ptr.Int64(50),
-					Target:      ptr.Float64(40.5),
-					Utilization: ptr.Float64(35.5),
+					Limit: ptr.Int64(50),
 				},
 				Scale: &ScaleOptions{
-					Min:    ptr.Int64(0),
-					Max:    ptr.Int64(10),
-					Metric: ptr.String("concurrency"),
+					Min:         ptr.Int64(0),
+					Max:         ptr.Int64(10),
+					Metric:      ptr.String("concurrency"),
+					Target:      ptr.Float64(40.5),
+					Utilization: ptr.Float64(35.5),
 				},
 			},
 			0,
@@ -690,14 +690,14 @@ func Test_validateOptions(t *testing.T) {
 			"incorrect all options",
 			Options{
 				Concurrency: &ConcurrencyOptions{
-					Limit:       ptr.Int64(-1),
-					Target:      ptr.Float64(-1),
-					Utilization: ptr.Float64(110),
+					Limit: ptr.Int64(-1),
 				},
 				Scale: &ScaleOptions{
-					Min:    ptr.Int64(-1),
-					Max:    ptr.Int64(-1),
-					Metric: ptr.String("foo"),
+					Min:         ptr.Int64(-1),
+					Max:         ptr.Int64(-1),
+					Metric:      ptr.String("foo"),
+					Target:      ptr.Float64(-1),
+					Utilization: ptr.Float64(110),
 				},
 			},
 			6,

--- a/config_test.go
+++ b/config_test.go
@@ -599,33 +599,6 @@ func Test_validateOptions(t *testing.T) {
 			1,
 		},
 		{
-			"correct 'concurrency.limit'",
-			Options{
-				Concurrency: &ConcurrencyOptions{
-					Limit: ptr.Int64(50),
-				},
-			},
-			0,
-		},
-		{
-			"correct 'concurrency.limit' - 0",
-			Options{
-				Concurrency: &ConcurrencyOptions{
-					Limit: ptr.Int64(0),
-				},
-			},
-			0,
-		},
-		{
-			"incorrect 'concurrency.limit' - negative value",
-			Options{
-				Concurrency: &ConcurrencyOptions{
-					Limit: ptr.Int64(-10),
-				},
-			},
-			1,
-		},
-		{
 			"correct 'scale.target'",
 			Options{
 				Scale: &ScaleOptions{
@@ -673,9 +646,6 @@ func Test_validateOptions(t *testing.T) {
 		{
 			"correct all options",
 			Options{
-				Concurrency: &ConcurrencyOptions{
-					Limit: ptr.Int64(50),
-				},
 				Scale: &ScaleOptions{
 					Min:         ptr.Int64(0),
 					Max:         ptr.Int64(10),
@@ -689,9 +659,6 @@ func Test_validateOptions(t *testing.T) {
 		{
 			"incorrect all options",
 			Options{
-				Concurrency: &ConcurrencyOptions{
-					Limit: ptr.Int64(-1),
-				},
 				Scale: &ScaleOptions{
 					Min:         ptr.Int64(-1),
 					Max:         ptr.Int64(-1),
@@ -700,7 +667,7 @@ func Test_validateOptions(t *testing.T) {
 					Utilization: ptr.Float64(110),
 				},
 			},
-			6,
+			5,
 		},
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -516,70 +516,191 @@ func Test_validateOptions(t *testing.T) {
 		errs    int
 	}{
 		{
-			"correct 'autoscale-window'",
+			"correct 'scale.metric' - concurrency",
 			Options{
-				AutoscaleWindow: ptr.String("10s"),
+				Scale: &ScaleOptions{
+					Metric: ptr.String("concurrency"),
+				},
 			},
 			0,
 		},
 		{
-			"incorrect 'autoscale-window' - missing unit",
+			"correct 'scale.metric' - rps",
 			Options{
-				AutoscaleWindow: ptr.String("10"),
+				Scale: &ScaleOptions{
+					Metric: ptr.String("rps"),
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'scale.metric'",
+			Options{
+				Scale: &ScaleOptions{
+					Metric: ptr.String("foo"),
+				},
 			},
 			1,
 		},
 		{
-			"incorrect 'autoscale-window' - wrong string",
+			"correct 'scale.min'",
 			Options{
-				AutoscaleWindow: ptr.String("foo"),
+				Scale: &ScaleOptions{
+					Min: ptr.Int64(1),
+				},
+			},
+			0,
+		},
+		{
+			"correct 'scale.max'",
+			Options{
+				Scale: &ScaleOptions{
+					Max: ptr.Int64(10),
+				},
+			},
+			0,
+		},
+		{
+			"correct  'scale.min' & 'scale.max'",
+			Options{
+				Scale: &ScaleOptions{
+					Min: ptr.Int64(0),
+					Max: ptr.Int64(10),
+				},
+			},
+			0,
+		},
+		{
+			"incorrect  'scale.min' & 'scale.max'",
+			Options{
+				Scale: &ScaleOptions{
+					Min: ptr.Int64(100),
+					Max: ptr.Int64(10),
+				},
 			},
 			1,
 		},
 		{
-			"correct 'concurrency-limit'",
+			"incorrect 'scale.min' - negative value",
 			Options{
-				ConcurrencyLimit: ptr.Int64(50),
+				Scale: &ScaleOptions{
+					Min: ptr.Int64(-10),
+				},
+			},
+			1,
+		},
+		{
+			"incorrect 'scale.max' - negative value",
+			Options{
+				Scale: &ScaleOptions{
+					Max: ptr.Int64(-10),
+				},
+			},
+			1,
+		},
+		{
+			"correct 'concurrency.limit'",
+			Options{
+				Concurrency: &ConcurrencyOptions{
+					Limit: ptr.Int64(50),
+				},
 			},
 			0,
 		},
 		{
-			"correct 'concurrency-limit' - 0",
+			"correct 'concurrency.limit' - 0",
 			Options{
-				ConcurrencyLimit: ptr.Int64(0),
+				Concurrency: &ConcurrencyOptions{
+					Limit: ptr.Int64(0),
+				},
 			},
 			0,
 		},
 		{
-			"incorrect 'concurrency-limit' - negative value",
+			"incorrect 'concurrency.limit' - negative value",
 			Options{
-				ConcurrencyLimit: ptr.Int64(-10),
+				Concurrency: &ConcurrencyOptions{
+					Limit: ptr.Int64(-10),
+				},
+			},
+			1,
+		},
+		{
+			"correct 'concurrency.target'",
+			Options{
+				Concurrency: &ConcurrencyOptions{
+					Target: ptr.Float64(50),
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'concurrency.target'",
+			Options{
+				Concurrency: &ConcurrencyOptions{
+					Target: ptr.Float64(0),
+				},
+			},
+			1,
+		},
+		{
+			"correct 'concurrency.utilization'",
+			Options{
+				Concurrency: &ConcurrencyOptions{
+					Utilization: ptr.Float64(50),
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'concurrency.utilization' - < 1",
+			Options{
+				Concurrency: &ConcurrencyOptions{
+					Utilization: ptr.Float64(0),
+				},
+			},
+			1,
+		},
+		{
+			"incorrect 'concurrency.utilization' - > 100",
+			Options{
+				Concurrency: &ConcurrencyOptions{
+					Utilization: ptr.Float64(110),
+				},
 			},
 			1,
 		},
 		{
 			"correct all options",
 			Options{
-				ConcurrencyLimit: ptr.Int64(50),
-				AutoscaleWindow:  ptr.String("10s"),
+				Concurrency: &ConcurrencyOptions{
+					Limit:       ptr.Int64(50),
+					Target:      ptr.Float64(40.5),
+					Utilization: ptr.Float64(35.5),
+				},
+				Scale: &ScaleOptions{
+					Min:    ptr.Int64(0),
+					Max:    ptr.Int64(10),
+					Metric: ptr.String("concurrency"),
+				},
 			},
 			0,
 		},
 		{
 			"incorrect all options",
 			Options{
-				ConcurrencyLimit: ptr.Int64(-10),
-				AutoscaleWindow:  ptr.String("foo"),
+				Concurrency: &ConcurrencyOptions{
+					Limit:       ptr.Int64(-1),
+					Target:      ptr.Float64(-1),
+					Utilization: ptr.Float64(110),
+				},
+				Scale: &ScaleOptions{
+					Min:    ptr.Int64(-1),
+					Max:    ptr.Int64(-1),
+					Metric: ptr.String("foo"),
+				},
 			},
-			2,
-		},
-		{
-			"incorrect and correct options",
-			Options{
-				ConcurrencyLimit: ptr.Int64(50),
-				AutoscaleWindow:  ptr.String("foo"),
-			},
-			1,
+			6,
 		},
 	}
 

--- a/docs/guides/func_yaml.md
+++ b/docs/guides/func_yaml.md
@@ -68,10 +68,10 @@ Options allows you to set specific configuration for the deployed function, allo
   - `min`: Minimum number of replicas. Must me non-negative integer, default is 0. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#lower-bound).
   - `max`: Maximum number of replicas. Must me non-negative integer, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#upper-bound).
   - `metric`: Defines which metric type is watched by the Autoscaler. Could be `concurrency` (default) or `rps`. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/autoscaling-metrics/).
+  - `target`: Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to `concurrency.limit` when given. Can be float value greater than 0.01, default is 100. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit).
+  - `utilization`: Percentage of concurrent requests utilization before scaling up. Can be float value between 1 and 100, default is 70. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#target-utilization).
 - `concurrency` 
   - `limit`: Hard Limit of concurrent requests to be processed by a single replica. Can be integer value greater than or equal to 0, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#hard-limit).
-  - `target`: Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to `limit` when given. Can be float value greater than 0.01, default is 100. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit).
-  - `utilization`: Percentage of concurrent requests utilization before scaling up. Can be float value between 1 and 100, default is 70. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#target-utilization).
 
 ```yaml
 options:
@@ -79,10 +79,10 @@ options:
     min: 0
     max: 10
     metric: concurrency
-  concurrency:
-    limit: 100
     target: 75
     utilization: 75
+  concurrency:
+    limit: 100
 ```
 
 ### `image`

--- a/docs/guides/func_yaml.md
+++ b/docs/guides/func_yaml.md
@@ -62,6 +62,27 @@ volumes:
   path: /workspace/configmap
 ```
 
+### `options`
+Options allows you to set specific configuration for the deployed funciton, ie. it allows you to tweak Knative Service options related to autoscaling and other properties, if these options are not set in the default ones will be used. This options are based on the ones provided by `kn service` [command](https://github.com/knative/client/blob/main/docs/cmd/kn_service_create.md#options).
+- `scale-min`: Minimum number of replicas.
+- `scale-max`: Maximum number of replicas.
+- `scale-init`: Initial number of replicas with which a Service starts. Can be 0 or a positive integer.
+- `autoscale-window`: Duration to look back for making auto-scaling decisions. The Service is scaled to zero if no request was received in during that time. (eg: 10s)
+- `concurrency-limit`: Hard Limit of concurrent requests to be processed by a single replica.
+- `concurrency-target`: Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to `concurrency-limit` when given.
+- `concurrency-utilization`: Percentage of concurrent requests utilization before scaling up.
+
+```yaml
+options:
+  scale-min: 0
+  scale-max: 10
+  scale-init: 2
+  autoscale-window: 10s
+  concurrency-limit: 100
+  concurrency-target: 75
+  concurrency-utilization: 75
+```
+
 ### `image`
 
 This is the image name for your function after it has been built. This field

--- a/docs/guides/func_yaml.md
+++ b/docs/guides/func_yaml.md
@@ -63,24 +63,26 @@ volumes:
 ```
 
 ### `options`
-Options allows you to set specific configuration for the deployed funciton, ie. it allows you to tweak Knative Service options related to autoscaling and other properties, if these options are not set in the default ones will be used. This options are based on the ones provided by `kn service` [command](https://github.com/knative/client/blob/main/docs/cmd/kn_service_create.md#options).
-- `scale-min`: Minimum number of replicas.
-- `scale-max`: Maximum number of replicas.
-- `scale-init`: Initial number of replicas with which a Service starts. Can be 0 or a positive integer.
-- `autoscale-window`: Duration to look back for making auto-scaling decisions. The Service is scaled to zero if no request was received in during that time. (eg: 10s)
-- `concurrency-limit`: Hard Limit of concurrent requests to be processed by a single replica.
-- `concurrency-target`: Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to `concurrency-limit` when given.
-- `concurrency-utilization`: Percentage of concurrent requests utilization before scaling up.
+Options allows you to set specific configuration for the deployed function, allowing you to tweak Knative Service options related to autoscaling and other properties. If these options are not set, the Knative defaults will be used. 
+- `scale`
+  - `min`: Minimum number of replicas. Must me non-negative integer, default is 0. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#lower-bound).
+  - `max`: Maximum number of replicas. Must me non-negative integer, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#upper-bound).
+  - `metric`: Defines which metric type is watched by the Autoscaler. Could be `concurrency` (default) or `rps`. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/autoscaling-metrics/).
+- `concurrency` 
+  - `limit`: Hard Limit of concurrent requests to be processed by a single replica. Can be integer value greater than or equal to 0, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#hard-limit).
+  - `target`: Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to `limit` when given. Can be float value greater than 0.01, default is 100. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit).
+  - `utilization`: Percentage of concurrent requests utilization before scaling up. Can be float value between 1 and 100, default is 70. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#target-utilization).
 
 ```yaml
 options:
-  scale-min: 0
-  scale-max: 10
-  scale-init: 2
-  autoscale-window: 10s
-  concurrency-limit: 100
-  concurrency-target: 75
-  concurrency-utilization: 75
+  scale:
+    min: 0
+    max: 10
+    metric: concurrency
+  concurrency:
+    limit: 100
+    target: 75
+    utilization: 75
 ```
 
 ### `image`

--- a/docs/guides/func_yaml.md
+++ b/docs/guides/func_yaml.md
@@ -68,10 +68,9 @@ Options allows you to set specific configuration for the deployed function, allo
   - `min`: Minimum number of replicas. Must me non-negative integer, default is 0. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#lower-bound).
   - `max`: Maximum number of replicas. Must me non-negative integer, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#upper-bound).
   - `metric`: Defines which metric type is watched by the Autoscaler. Could be `concurrency` (default) or `rps`. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/autoscaling-metrics/).
-  - `target`: Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to `concurrency.limit` when given. Can be float value greater than 0.01, default is 100. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit).
+  - `target`: Recommendation for when to scale up based on the concurrent number of incoming request. Can be float value greater than 0.01, default is 100. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit).
   - `utilization`: Percentage of concurrent requests utilization before scaling up. Can be float value between 1 and 100, default is 70. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#target-utilization).
-- `concurrency` 
-  - `limit`: Hard Limit of concurrent requests to be processed by a single replica. Can be integer value greater than or equal to 0, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#hard-limit).
+
 
 ```yaml
 options:
@@ -81,8 +80,6 @@ options:
     metric: concurrency
     target: 75
     utilization: 75
-  concurrency:
-    limit: 100
 ```
 
 ### `image`

--- a/function.go
+++ b/function.go
@@ -55,12 +55,15 @@ type Function struct {
 	// List of volumes to be mounted to the function
 	Volumes Volumes
 
-	// Env variables to be set 
+	// Env variables to be set
 	Envs Envs
 
 	// Map containing user-supplied annotations
 	// Example: { "division": "finance" }
 	Annotations map[string]string
+
+	// Options to be set on deployed function (scaling, etc.)
+	Options Options
 }
 
 // NewFunction loads a Function from a path on disk. use .Initialized() to determine if

--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,7 +14,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/client/pkg/kn/flags"
+	servingclientlib "knative.dev/client/pkg/serving"
 	"knative.dev/client/pkg/wait"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 
@@ -52,7 +55,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (result fn.Deploym
 			referencedSecrets := sets.NewString()
 			referencedConfigMaps := sets.NewString()
 
-			service, err := generateNewService(f.Name, f.ImageWithDigest(), f.Runtime, f.Envs, f.Volumes, f.Annotations)
+			service, err := generateNewService(f.Name, f.ImageWithDigest(), f.Runtime, f.Envs, f.Volumes, f.Annotations, f.Options)
 			if err != nil {
 				err = fmt.Errorf("knative deployer failed to generate the Knative Service: %v", err)
 				return fn.DeploymentResult{}, err
@@ -116,7 +119,7 @@ func (d *Deployer) Deploy(ctx context.Context, f fn.Function) (result fn.Deploym
 			return fn.DeploymentResult{}, err
 		}
 
-		_, err = client.UpdateServiceWithRetry(ctx, f.Name, updateService(f.ImageWithDigest(), newEnv, newEnvFrom, newVolumes, newVolumeMounts, f.Annotations), 3)
+		_, err = client.UpdateServiceWithRetry(ctx, f.Name, updateService(f.ImageWithDigest(), newEnv, newEnvFrom, newVolumes, newVolumeMounts, f.Annotations, f.Options), 3)
 		if err != nil {
 			err = fmt.Errorf("knative deployer failed to update the Knative Service: %v", err)
 			return fn.DeploymentResult{}, err
@@ -145,7 +148,7 @@ func probeFor(url string) *corev1.Probe {
 	}
 }
 
-func generateNewService(name, image, runtime string, envs fn.Envs, volumes fn.Volumes, annotations map[string]string) (*servingv1.Service, error) {
+func generateNewService(name, image, runtime string, envs fn.Envs, volumes fn.Volumes, annotations map[string]string, options fn.Options) (*servingv1.Service, error) {
 	containers := []corev1.Container{
 		{
 			Image: image,
@@ -196,11 +199,16 @@ func generateNewService(name, image, runtime string, envs fn.Envs, volumes fn.Vo
 		},
 	}
 
+	err = setServiceOptions(&service.Spec.Template, options)
+	if err != nil {
+		return service, err
+	}
+
 	return service, nil
 }
 
 func updateService(image string, newEnv []corev1.EnvVar, newEnvFrom []corev1.EnvFromSource, newVolumes []corev1.Volume, newVolumeMounts []corev1.VolumeMount,
-	annotations map[string]string) func(service *servingv1.Service) (*servingv1.Service, error) {
+	annotations map[string]string, options fn.Options) func(service *servingv1.Service) (*servingv1.Service, error) {
 	return func(service *servingv1.Service) (*servingv1.Service, error) {
 		// Removing the name so the k8s server can fill it in with generated name,
 		// this prevents conflicts in Revision name when updating the KService from multiple places.
@@ -212,7 +220,12 @@ func updateService(image string, newEnv []corev1.EnvVar, newEnvFrom []corev1.Env
 			service.ObjectMeta.Annotations[k] = v
 		}
 
-		err := flags.UpdateImage(&service.Spec.Template.Spec.PodSpec, image)
+		err := setServiceOptions(&service.Spec.Template, options)
+		if err != nil {
+			return service, err
+		}
+
+		err = flags.UpdateImage(&service.Spec.Template.Spec.PodSpec, image)
 		if err != nil {
 			return service, err
 		}
@@ -508,4 +521,52 @@ func checkSecretsConfigMapsArePresent(ctx context.Context, namespace string, ref
 	}
 
 	return nil
+}
+
+// setServiceOptions sets annotations on Service Revision Template or in the Service Spec
+// from values specifed in function configuration options
+func setServiceOptions(template *servingv1.RevisionTemplateSpec, options fn.Options) error {
+
+	toRemove := []string{}
+	toUpdate := map[string]string{}
+
+	if options.ScaleMin != nil {
+		toUpdate[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(*options.ScaleMin)
+	} else {
+		toRemove = append(toRemove, autoscaling.MinScaleAnnotationKey)
+	}
+
+	if options.ScaleMax != nil {
+		toUpdate[autoscaling.MaxScaleAnnotationKey] = strconv.Itoa(*options.ScaleMax)
+	} else {
+		toRemove = append(toRemove, autoscaling.MaxScaleAnnotationKey)
+	}
+
+	if options.ScaleInit != nil {
+		toUpdate[autoscaling.InitialScaleAnnotationKey] = strconv.Itoa(*options.ScaleInit)
+	} else {
+		toRemove = append(toRemove, autoscaling.InitialScaleAnnotationKey)
+	}
+
+	if options.AutoscaleWindow != nil {
+		toUpdate[autoscaling.WindowAnnotationKey] = *options.AutoscaleWindow
+	} else {
+		toRemove = append(toRemove, autoscaling.WindowAnnotationKey)
+	}
+
+	template.Spec.ContainerConcurrency = options.ConcurrencyLimit
+
+	if options.ConcurrencyTarget != nil {
+		toUpdate[autoscaling.TargetAnnotationKey] = strconv.Itoa(*options.ConcurrencyTarget)
+	} else {
+		toRemove = append(toRemove, autoscaling.TargetAnnotationKey)
+	}
+
+	if options.ConcurrencyUtilizatin != nil {
+		toUpdate[autoscaling.TargetUtilizationPercentageKey] = strconv.Itoa(*options.ConcurrencyUtilizatin)
+	} else {
+		toRemove = append(toRemove, autoscaling.TargetUtilizationPercentageKey)
+	}
+
+	return servingclientlib.UpdateRevisionTemplateAnnotations(template, toUpdate, toRemove)
 }

--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -547,22 +547,22 @@ func setServiceOptions(template *servingv1.RevisionTemplateSpec, options fn.Opti
 		} else {
 			toRemove = append(toRemove, autoscaling.MetricAnnotationKey)
 		}
-	}
 
-	if options.Concurrency != nil {
-		template.Spec.ContainerConcurrency = options.Concurrency.Limit
-
-		if options.Concurrency.Target != nil {
-			toUpdate[autoscaling.TargetAnnotationKey] = fmt.Sprintf("%f", *options.Concurrency.Target)
+		if options.Scale.Target != nil {
+			toUpdate[autoscaling.TargetAnnotationKey] = fmt.Sprintf("%f", *options.Scale.Target)
 		} else {
 			toRemove = append(toRemove, autoscaling.TargetAnnotationKey)
 		}
 
-		if options.Concurrency.Utilization != nil {
-			toUpdate[autoscaling.TargetUtilizationPercentageKey] = fmt.Sprintf("%f", *options.Concurrency.Utilization)
+		if options.Scale.Utilization != nil {
+			toUpdate[autoscaling.TargetUtilizationPercentageKey] = fmt.Sprintf("%f", *options.Scale.Utilization)
 		} else {
 			toRemove = append(toRemove, autoscaling.TargetUtilizationPercentageKey)
 		}
+	}
+
+	if options.Concurrency != nil {
+		template.Spec.ContainerConcurrency = options.Concurrency.Limit
 	}
 
 	return servingclientlib.UpdateRevisionTemplateAnnotations(template, toUpdate, toRemove)

--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -561,9 +561,5 @@ func setServiceOptions(template *servingv1.RevisionTemplateSpec, options fn.Opti
 		}
 	}
 
-	if options.Concurrency != nil {
-		template.Spec.ContainerConcurrency = options.Concurrency.Limit
-	}
-
 	return servingclientlib.UpdateRevisionTemplateAnnotations(template, toUpdate, toRemove)
 }


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Users can specify (autoscaling) options in `func.yaml`. The options are added/update/removed based on the content in `func.yaml` file.

If there's a demand, we can add these options as flags to `func deploy` command (same way they are exposed in `kn service create/update` -> with removal option), but I think that specification in config file is enough.


```yaml
name: test
namespace: ""
runtime: go
...
options:
  scale:
    min: 0
    max: 10
    metric: rps
    target: 75
    utilization: 75
```

`concurrency.limit` will be added in the following PR, which will handle resource limits/requests as proposed here: https://github.com/boson-project/func/pull/374#discussion_r649070413

Relates: #164
Fixes: #264