### PR TITLE
chore: fix dead link on the developers guide.

### DIFF
--- a/docs/guides/developers_guide.md
+++ b/docs/guides/developers_guide.md
@@ -8,7 +8,7 @@ To learn how to work with functions quickly, have a look at the [developer's tut
 
 ## CLI Command Reference
 
-For detailed documentation on the CLI and its commands, please see the [Commands document](commands).
+For detailed documentation on the CLI and its commands, please see the [Commands document](commands.md).
 
 ## Function Project Configuration
 


### PR DESCRIPTION
* The link from the developers guide to the cli command reference guide was missing the file extension