### PR TITLE
feat: allow setting resource requests/limits

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -644,8 +644,140 @@ func Test_validateOptions(t *testing.T) {
 			1,
 		},
 		{
+			"correct 'resources.requests.cpu'",
+			Options{
+				Resources: &ResourcesOptions{
+					Requests: &ResourcesRequestsOptions{
+						CPU: ptr.String("1000m"),
+					},
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'resources.requests.cpu'",
+			Options{
+				Resources: &ResourcesOptions{
+					Requests: &ResourcesRequestsOptions{
+						CPU: ptr.String("foo"),
+					},
+				},
+			},
+			1,
+		},
+		{
+			"correct 'resources.requests.memory'",
+			Options{
+				Resources: &ResourcesOptions{
+					Requests: &ResourcesRequestsOptions{
+						Memory: ptr.String("100Mi"),
+					},
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'resources.requests.memory'",
+			Options{
+				Resources: &ResourcesOptions{
+					Requests: &ResourcesRequestsOptions{
+						Memory: ptr.String("foo"),
+					},
+				},
+			},
+			1,
+		},
+		{
+			"correct 'resources.limits.cpu'",
+			Options{
+				Resources: &ResourcesOptions{
+					Limits: &ResourcesLimitsOptions{
+						CPU: ptr.String("1000m"),
+					},
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'resources.limits.cpu'",
+			Options{
+				Resources: &ResourcesOptions{
+					Limits: &ResourcesLimitsOptions{
+						CPU: ptr.String("foo"),
+					},
+				},
+			},
+			1,
+		},
+		{
+			"correct 'resources.limits.memory'",
+			Options{
+				Resources: &ResourcesOptions{
+					Limits: &ResourcesLimitsOptions{
+						Memory: ptr.String("100Mi"),
+					},
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'resources.limits.memory'",
+			Options{
+				Resources: &ResourcesOptions{
+					Limits: &ResourcesLimitsOptions{
+						Memory: ptr.String("foo"),
+					},
+				},
+			},
+			1,
+		},
+		{
+			"correct 'resources.limits.concurrency'",
+			Options{
+				Resources: &ResourcesOptions{
+					Limits: &ResourcesLimitsOptions{
+						Concurrency: ptr.Int64(50),
+					},
+				},
+			},
+			0,
+		},
+		{
+			"correct 'resources.limits.concurrency' - 0",
+			Options{
+				Resources: &ResourcesOptions{
+					Limits: &ResourcesLimitsOptions{
+						Concurrency: ptr.Int64(0),
+					},
+				},
+			},
+			0,
+		},
+		{
+			"incorrect 'resources.limits.concurrency' - negative value",
+			Options{
+				Resources: &ResourcesOptions{
+					Limits: &ResourcesLimitsOptions{
+						Concurrency: ptr.Int64(-10),
+					},
+				},
+			},
+			1,
+		},
+		{
 			"correct all options",
 			Options{
+				Resources: &ResourcesOptions{
+					Requests: &ResourcesRequestsOptions{
+						CPU:    ptr.String("1000m"),
+						Memory: ptr.String("100Mi"),
+					},
+					Limits: &ResourcesLimitsOptions{
+						CPU:         ptr.String("1000m"),
+						Memory:      ptr.String("100Mi"),
+						Concurrency: ptr.Int64(10),
+					},
+				},
 				Scale: &ScaleOptions{
 					Min:         ptr.Int64(0),
 					Max:         ptr.Int64(10),
@@ -659,6 +791,17 @@ func Test_validateOptions(t *testing.T) {
 		{
 			"incorrect all options",
 			Options{
+				Resources: &ResourcesOptions{
+					Requests: &ResourcesRequestsOptions{
+						CPU:    ptr.String("foo"),
+						Memory: ptr.String("foo"),
+					},
+					Limits: &ResourcesLimitsOptions{
+						CPU:         ptr.String("foo"),
+						Memory:      ptr.String("foo"),
+						Concurrency: ptr.Int64(-1),
+					},
+				},
 				Scale: &ScaleOptions{
 					Min:         ptr.Int64(-1),
 					Max:         ptr.Int64(-1),
@@ -667,7 +810,7 @@ func Test_validateOptions(t *testing.T) {
 					Utilization: ptr.Float64(110),
 				},
 			},
-			5,
+			10,
 		},
 	}
 

--- a/docs/guides/func_yaml.md
+++ b/docs/guides/func_yaml.md
@@ -68,9 +68,16 @@ Options allows you to set specific configuration for the deployed function, allo
   - `min`: Minimum number of replicas. Must me non-negative integer, default is 0. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#lower-bound).
   - `max`: Maximum number of replicas. Must me non-negative integer, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/scale-bounds/#upper-bound).
   - `metric`: Defines which metric type is watched by the Autoscaler. Could be `concurrency` (default) or `rps`. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/autoscaling-metrics/).
-  - `target`: Recommendation for when to scale up based on the concurrent number of incoming request. Can be float value greater than 0.01, default is 100. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit).
+  - `target`: Recommendation for when to scale up based on the concurrent number of incoming request. Defaults to `options.resources.limits.concurrency` when given. Can be float value greater than 0.01, default is 100. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit).
   - `utilization`: Percentage of concurrent requests utilization before scaling up. Can be float value between 1 and 100, default is 70. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#target-utilization).
-
+- `resources`
+  - `requests` 
+    - `cpu`: A CPU resource request for the container with deployed function. See related [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
+    - `memory`: A memory resource request for the container with deployed function. See related [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
+  - `limits` 
+    - `cpu`: A CPU resource limit for the container with deployed function. See related [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
+    - `memory`: A memory resource limit for the container with deployed function. See related [Kubernetes docs](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits).
+    - `concurrency`: Hard Limit of concurrent requests to be processed by a single replica. Can be integer value greater than or equal to 0, default is 0 - meaning no limit. See related [Knative docs](https://knative.dev/docs/serving/autoscaling/concurrency/#hard-limit).
 
 ```yaml
 options:
@@ -80,6 +87,14 @@ options:
     metric: concurrency
     target: 75
     utilization: 75
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 256Mi
+      concurrency: 100
 ```
 
 ### `image`


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Follow up on https://github.com/boson-project/func/pull/374

Users can specify resource requests/limits (cpu&memory) and concurrency limit, which are applied on deployed KService.

```yaml
name: test
namespace: ""
runtime: go
...
options:
  scale:
    min: 2
    ...
  resources:
    requests:
      cpu: 100m
      memory: 128Mi
    limits:
      cpu: 1000m
      memory: 256Mi
      concurrency: 100
```


Fixes: #383