### PR TITLE
feat: add a URL output type for `func describe`

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	root.AddCommand(describeCmd)
 	describeCmd.Flags().StringP("namespace", "n", "", "Namespace of the function. By default, the namespace in func.yaml is used or the actual active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)")
-	describeCmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml) (Env: $FUNC_OUTPUT)")
+	describeCmd.Flags().StringP("output", "o", "human", "Output format (human|plain|json|xml|yaml|url) (Env: $FUNC_OUTPUT)")
 	describeCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
 
 	err := describeCmd.RegisterFlagCompletionFunc("output", CompleteOutputFormatList)
@@ -160,4 +160,11 @@ func (d description) XML(w io.Writer) error {
 
 func (d description) YAML(w io.Writer) error {
 	return yaml.NewEncoder(w).Encode(d)
+}
+
+func (d description) URL(w io.Writer) error {
+	if len(d.Routes) > 0 {
+		fmt.Fprint(w, d.Routes[0])
+	}
+	return nil
 }

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -164,7 +164,7 @@ func (d description) YAML(w io.Writer) error {
 
 func (d description) URL(w io.Writer) error {
 	if len(d.Routes) > 0 {
-		fmt.Fprint(w, d.Routes[0])
+		fmt.Fprintf(w, "%s\n", d.Routes[0])
 	}
 	return nil
 }

--- a/cmd/format.go
+++ b/cmd/format.go
@@ -14,6 +14,7 @@ const (
 	JSON         = "json"  // Technically a ⊆ yaml, but no one likes yaml.
 	XML          = "xml"
 	YAML         = "yaml"
+	URL          = "url"
 )
 
 // formatter is any structure which has methods for serialization.
@@ -23,6 +24,7 @@ type Formatter interface {
 	JSON(io.Writer) error
 	XML(io.Writer) error
 	YAML(io.Writer) error
+	URL(io.Writer) error
 }
 
 // write to the output the output of the formatter's appropriate serilization function.
@@ -40,6 +42,8 @@ func write(out io.Writer, s Formatter, formatName string) {
 		err = s.XML(out)
 	case YAML:
 		err = s.YAML(out)
+	case URL:
+		err = s.URL(out)
 	default:
 		err = fmt.Errorf("format not recognized: %v\n", formatName)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -135,3 +135,10 @@ func (items listItems) XML(w io.Writer) error {
 func (items listItems) YAML(w io.Writer) error {
 	return yaml.NewEncoder(w).Encode(items)
 }
+
+func (items listItems) URL(w io.Writer) error {
+	for _, item := range items {
+		fmt.Fprintf(w, "%s\n", item.URL)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #387