### PR TITLE
src: validate Env Var name

### DIFF
--- a/buildpacks/utils.go
+++ b/buildpacks/utils.go
@@ -1,16 +1,14 @@
-package utils
+package buildpacks
 
 import (
 	"sort"
 	"strings"
-
-	"github.com/boson-project/func/buildpacks"
 )
 
 //RuntimeList returns the list of supported runtimes
 //as comma seperated strings
 func RuntimeList() string {
-	rb := buildpacks.RuntimeToBuildpack
+	rb := RuntimeToBuildpack
 	runtimes := make([]string, 0, len(rb))
 	for k := range rb {
 		runtimes = append(runtimes, k)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	bosonFunc "github.com/boson-project/func"
+	"github.com/boson-project/func/buildpacks"
 	"github.com/boson-project/func/prompt"
 	"github.com/boson-project/func/utils"
 )
@@ -15,7 +16,7 @@ import (
 func init() {
 	root.AddCommand(createCmd)
 	createCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
-	createCmd.Flags().StringP("runtime", "l", bosonFunc.DefaultRuntime, "Function runtime language/framework. Available runtimes: "+utils.RuntimeList()+" (Env: $FUNC_RUNTIME)")
+	createCmd.Flags().StringP("runtime", "l", bosonFunc.DefaultRuntime, "Function runtime language/framework. Available runtimes: "+buildpacks.RuntimeList()+" (Env: $FUNC_RUNTIME)")
 	createCmd.Flags().StringP("repositories", "r", filepath.Join(configPath(), "repositories"), "Path to extended template repositories (Env: $FUNC_REPOSITORIES)")
 	createCmd.Flags().StringP("template", "t", bosonFunc.DefaultTemplate, "Function template. Available templates: 'http' and 'events' (Env: $FUNC_TEMPLATE)")
 

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/boson-project/func/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -261,6 +262,11 @@ func ValidateEnvs(envs Envs) (errors []string) {
 					i, *env.Value))
 			}
 		} else {
+
+			if err := utils.ValidateEnvVarName(*env.Name); err != nil {
+				errors = append(errors, fmt.Sprintf("env entry #%d has invalid name set: %q; %s", i, *env.Name, err.Error()))
+			}
+
 			if strings.HasPrefix(*env.Value, "{{") {
 				// ENV from the local ENV var; {{ env.MY_ENV }}
 				// or

--- a/config_test.go
+++ b/config_test.go
@@ -151,6 +151,9 @@ func Test_validateEnvs(t *testing.T) {
 	value := "value"
 	value2 := "value2"
 
+	incorrectName := ",foo"
+	incorrectName2 := ":foo"
+
 	valueLocalEnv := "{{ env.MY_ENV }}"
 	valueLocalEnv2 := "{{ env.MY_ENV2 }}"
 	valueLocalEnv3 := "{{env.MY_ENV3}}"
@@ -194,6 +197,26 @@ func Test_validateEnvs(t *testing.T) {
 			Envs{
 				Env{
 					Name: &name,
+				},
+			},
+			1,
+		},
+		{
+			"incorrect entry - invalid name",
+			Envs{
+				Env{
+					Name:  &incorrectName,
+					Value: &value,
+				},
+			},
+			1,
+		},
+		{
+			"incorrect entry - invalid name2",
+			Envs{
+				Env{
+					Name:  &incorrectName2,
+					Value: &value,
 				},
 			},
 			1,

--- a/utils/names.go
+++ b/utils/names.go
@@ -23,3 +23,14 @@ func ValidateFunctionName(name string) error {
 
 	return nil
 }
+
+// ValidateEnvVarName validatest that the input name is a valid Kubernetes Environmet Variable name.
+// It must  must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit
+// (e.g. 'my.env-name',  or 'MY_ENV.NAME',  or 'MyEnvName1', regex used for validation is '[-._a-zA-Z][-._a-zA-Z0-9]*'))
+func ValidateEnvVarName(name string) error {
+	if errs := validation.IsEnvVarName(name); len(errs) > 0 {
+		return errors.New(strings.Join(errs, ""))
+	}
+
+	return nil
+}

--- a/utils/names_test.go
+++ b/utils/names_test.go
@@ -4,7 +4,6 @@ package utils
 
 import "testing"
 
-
 // TestValidateFunctionName tests that only correct function names are accepted
 func TestValidateFunctionName(t *testing.T) {
 	cases := []struct {
@@ -27,6 +26,39 @@ func TestValidateFunctionName(t *testing.T) {
 		err := ValidateFunctionName(c.In)
 		if err != nil && c.Valid {
 			t.Fatalf("Unexpected error: %v, for '%v'", err, c.In)
+		}
+		if err == nil && !c.Valid {
+			t.Fatalf("Expected error for invalid entry: %v", c.In)
+		}
+	}
+}
+
+func TestValidateEnvVarName(t *testing.T) {
+	cases := []struct {
+		In    string
+		Valid bool
+	}{
+		{"", false},
+		{"*", false},
+		{"example", true},
+		{"example-com", true},
+		{"example.com", true},
+		{"-example-com", true},
+		{"example-com-", true},
+		{"Example", true},
+		{"EXAMPLE", true},
+		{";Example", false},
+		{":Example", false},
+		{",Example", false},
+	}
+
+	for _, c := range cases {
+		err := ValidateEnvVarName(c.In)
+		if err != nil && c.Valid {
+			t.Fatalf("Unexpected error: %v, for '%v'", err, c.In)
+		}
+		if err == nil && !c.Valid {
+			t.Fatalf("Expected error for invalid entry: %v", c.In)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Minor improvement, let's check that the input k8s Env Variable name is valid:

```terminal
./func deploy                                                                                                  
Error: 'func.yaml' config file is not valid:
  env entry #1 has invalid name set to "in,valid"; a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit (e.g. 'my.env-name',  or 'MY_ENV.NAME',  or 'MyEnvName1', regex used for validation is '[-._a-zA-Z][-._a-zA-Z0-9]*')
```

I have moved the buildpacks related utils to buildpacks package to prevent circular dependencies.

Relates: #362 