### PR TITLE
src: `create`- use Select for specifying runtime in interactive mode

### DIFF
--- a/buildpacks/utils.go
+++ b/buildpacks/utils.go
@@ -5,18 +5,27 @@ import (
 	"strings"
 )
 
-//RuntimeList returns the list of supported runtimes
-//as comma seperated strings
-func RuntimeList() string {
+//Runtimes returns the list of supported runtimes
+//as comma seperated strings, sorted alphabetically
+func Runtimes() string {
+	runtimes := RuntimesList()
+
+	//make it more grammatical :)
+	s := runtimes[:len(runtimes)-1]
+	str := strings.Join(s, ", ")
+	str = str + " and " + runtimes[len(runtimes)-1]
+	return str
+}
+
+//RuntimesList returns the list of supported runtimes
+//as an array of strings, sorted alphabetically
+func RuntimesList() []string {
 	rb := RuntimeToBuildpack
 	runtimes := make([]string, 0, len(rb))
 	for k := range rb {
 		runtimes = append(runtimes, k)
 	}
 	sort.Strings(runtimes)
-	//make it more grammatical :)
-	s := runtimes[:len(runtimes)-1]
-	str := strings.Join(s, ", ")
-	str = str + " and " + runtimes[len(runtimes)-1]
-	return str
+
+	return runtimes
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -17,7 +17,7 @@ import (
 func init() {
 	root.AddCommand(createCmd)
 	createCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
-	createCmd.Flags().StringP("runtime", "l", bosonFunc.DefaultRuntime, "Function runtime language/framework. Available runtimes: "+buildpacks.RuntimeList()+" (Env: $FUNC_RUNTIME)")
+	createCmd.Flags().StringP("runtime", "l", bosonFunc.DefaultRuntime, "Function runtime language/framework. Available runtimes: "+buildpacks.Runtimes()+" (Env: $FUNC_RUNTIME)")
 	createCmd.Flags().StringP("repositories", "r", filepath.Join(configPath(), "repositories"), "Path to extended template repositories (Env: $FUNC_REPOSITORIES)")
 	createCmd.Flags().StringP("template", "t", bosonFunc.DefaultTemplate, "Function template. Available templates: 'http' and 'events' (Env: $FUNC_TEMPLATE)")
 
@@ -163,12 +163,11 @@ func (c createConfig) Prompt() (createConfig, error) {
 		},
 		{
 			Name: "runtime",
-			Prompt: &survey.Input{
+			Prompt: &survey.Select{
 				Message: "Runtime:",
+				Options: buildpacks.RuntimesList(),
 				Default: c.Runtime,
-				// TODO add runtime suggestions: https://github.com/AlecAivazis/survey#suggestion-options
 			},
-			Validate: survey.Required,
 		},
 		{
 			Name: "template",


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Minor improvement, because we know all the runtimes, we can use Select instead of Input when interactive mode is selected in `func create`

![create](https://user-images.githubusercontent.com/726523/122735470-5b566400-d27f-11eb-8e5a-95dd417ed9fe.png)
