### PR TITLE
fix: pack logger failing on verbose

### DIFF
--- a/client_int_test.go
+++ b/client_int_test.go
@@ -133,6 +133,8 @@ func TestRemove(t *testing.T) {
 	}
 	waitFor(t, client, "remove")
 
+	time.Sleep(1 * time.Minute)
+
 	if err := client.Remove(context.Background(), boson.Function{Name: "remove"}); err != nil {
 		t.Fatal(err)
 	}
@@ -153,8 +155,6 @@ func TestRemove(t *testing.T) {
 // newClient creates an instance of the func client whose concrete impls
 // match those created by the kn func plugin CLI.
 func newClient(verbose bool) *boson.Client {
-	// TODO: Forcing verbose to false in order to pass integration tests
-	verbose = false
 	builder := buildpacks.NewBuilder()
 	builder.Verbose = verbose
 

--- a/cloudevents/emitter_test.go
+++ b/cloudevents/emitter_test.go
@@ -1,3 +1,5 @@
+// +build !integration
+
 package cloudevents
 
 import (


### PR DESCRIPTION
The Pack logger was failing silently when passed a logger whose
output was set to stdout.  This required hard coding verbose to
false.  This works around the issue by always buffering output,
and only writing it to stdout when verbose loggin.