### PR TITLE
chore(CI): use container-tools/kind for integration tests

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
       - name: Provision Cluster
-        uses: lkingland/kind-action@v1 # use ./hack/allocate.sh locally
+        uses: container-tools/kind-action@v1 # use ./hack/allocate.sh locally
         with:
           version: v0.10.0
           kubectl_version: v1.20.0


### PR DESCRIPTION
I noticed during the frenzy to get integration and e2e tests working in CI that one of our jobs was still using @lkingland's fork. The upstream has those changes now.

Signed-off-by: Lance Ball <lball@redhat.com>