### PR TITLE
fix: closing stdout

### DIFF
--- a/client_int_test.go
+++ b/client_int_test.go
@@ -153,8 +153,6 @@ func TestRemove(t *testing.T) {
 // newClient creates an instance of the func client whose concrete impls
 // match those created by the kn func plugin CLI.
 func newClient(verbose bool) *boson.Client {
-	// TODO: Forcing verbose to false in order to pass integration tests
-	verbose = false
 	builder := buildpacks.NewBuilder()
 	builder.Verbose = verbose
 


### PR DESCRIPTION
If you pass `io.WriteCloser` as loggin output for `pack` it will close it, `os.Stdout` does implement `io.WriteCloser` so it ended up closed which is not really good. I added wrapping struct that implements only `io.Writer` to fix the issue.

Signed-off-by: Matej Vasek <mvasek@redhat.com>