### PR TITLE
src: testable commands

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -80,11 +80,11 @@ jobs:
       - name: Provision Cluster
         uses: container-tools/kind-action@v1 # use ./hack/allocate.sh locally
         with:
-          version: v0.10.0
-          kubectl_version: v1.20.0
-          knative_serving: v0.22.0
-          knative_kourier: v0.22.0
-          knative_eventing: v0.22.0
+          version: v0.11.1
+          kubectl_version: v1.21.2
+          knative_serving: v0.23.0
+          knative_kourier: v0.23.0
+          knative_eventing: v0.23.0
           config: testdata/cluster.yaml
       - name: Configure Cluster
         run: ./hack/configure.sh

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -17,7 +17,7 @@ func TestCreateValidatesName(t *testing.T) {
 
 	// Create a new Create command with a fn.Client construtor
 	// which returns a default (noop) client suitable for tests.
-	cmd := NewCreateCmd(func(string, bool) *fn.Client {
+	cmd := NewCreateCmd(func(createConfig) *fn.Client {
 		return fn.New()
 	})
 

--- a/knative/client.go
+++ b/knative/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultWaitingTimeout = 60 * time.Second
+	DefaultWaitingTimeout = 120 * time.Second
 )
 
 func NewServingClient(namespace string) (clientservingv1.KnServingClient, error) {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -153,6 +153,13 @@ func (b *Bar) Complete(text string) {
 	b.Done() // stop spinner
 }
 
+// Stopping indicates the process is stopping, such as having received a context
+// cancellation.
+func (b *Bar) Stopping() {
+	// currently stopping is equivalent in effect to Done
+	b.Done()
+}
+
 // Done cancels the write loop if being used.
 // Call in a defer statement after creation to ensure that the spinner stops
 func (b *Bar) Done() {


### PR DESCRIPTION
Restructures commands to accept a fn.Client constructor on command instantiation.  This allows the concrete implementations, or entire client, to be mocked for testing.  Also includes some minor refactoring as necessary to shoehorn into the pattern.