### PR TITLE
docs: fix link to func.yaml docs in language guides

### DIFF
--- a/docs/guides/golang.md
+++ b/docs/guides/golang.md
@@ -23,7 +23,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any Go project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](config-reference.doc).
+If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](commands.md#cli-commands).
 

--- a/docs/guides/nodejs.md
+++ b/docs/guides/nodejs.md
@@ -24,7 +24,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any Node.js project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](config-reference.doc).
+If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](commands.md#cli-commands).
 

--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -22,7 +22,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any Python project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](config-reference.doc).
+If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](commands.md#cli-commands).
 

--- a/docs/guides/quarkus.md
+++ b/docs/guides/quarkus.md
@@ -34,9 +34,9 @@ fn
 ```
 
 Aside from the `func.yaml` file, this looks like the beginning of just about
-any Java maven project. For now, we will ignore the `func.yaml` file, and just
+any Java Maven project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file that is used when building your project.
-If you're really interested, check out the [reference doc](config-reference.doc).
+If you're really interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](commands.md#cli-commands).
 

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -27,7 +27,7 @@ fn
 Aside from the `func.yaml` file, this looks like the beginning of just about
 any TypeScript project. For now, we will ignore the `func.yaml` file, and just
 say that it is a configuration file used when building your project.
-If you are interested, check out the [reference doc](config-reference.doc).
+If you are interested, check out the [reference doc](func_yaml.md).
 To learn more about the CLI and the details for each supported command, see
 the [CLI Commands document](commands.md#cli-commands).
 


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>


Fixes: #417